### PR TITLE
Fixes for crates that were broken after toml migration

### DIFF
--- a/index/ad/ada_lua.toml
+++ b/index/ad/ada_lua.toml
@@ -8,7 +8,6 @@ maintainers = ["AdaCore"]
 ['0.0.0-5.3']
 origin = "git+https://github.com/alire-project/ada-lua.git@ba2fcbf9f8d54d3f6362f20523deb4371371f658"
 project-files = ["lua.gpr"]
-executables = ["main"]
 
     ['0.0.0-5.3'.depends-on]
     liblua = "^5.3"

--- a/index/ad/adayaml_server.toml
+++ b/index/ad/adayaml_server.toml
@@ -10,6 +10,7 @@ executables = ["yaml-server"]
 
     [general.depends-on]
     aunit = "^2017"
+    gnatcoll_connections = "^4.27"
 
     [general.gpr-externals]
     Mode = ["debug", "release"]

--- a/index/al/alire.toml
+++ b/index/al/alire.toml
@@ -4,31 +4,33 @@ licenses = ["GPL 3.0"]
 authors = ["Alejandro R. Mosteo"]
 maintainers = ["alejandro@mosteo.com"]
 
-['0.6']
-origin = "git+https://github.com/alire-project/alire.git@f418890a85f421b20ad00f1f52259c122f883aca"
+# Old versions no longer work due to repo renamings
 
-    ['0.6'.depends-on]
-    aaa = "^1.0.0"
-    semantic_versioning = "~0.3.2"
-    simple_logging = "^1.0"
-
-['0.5']
-origin = "git+https://github.com/alire-project/alire.git@f418890a85f421b20ad00f1f52259c122f883aca"
-
-    ['0.5'.depends-on]
-    semantic_versioning = "~0.3.2"
-    simple_logging = "^1.0"
-
-['0.4']
-origin = "git+https://github.com/alire-project/alire.git@219cdcbc5f26efca331400582026c6377ef0f794"
-
-    ['0.4'.depends-on]
-    semantic_versioning = "~0.3.1"
-    simple_logging = "^1.0"
-
-['0.2']
-origin = "git+https://github.com/alire-project/alire.git@5ba81ba33dfeb184b2e644ef2996200b5fdd6ae4"
-
-    ['0.2'.depends-on]
-    semantic_versioning = "~0.3"
-    simple_logging = "^1.0"
+#['0.6']
+#origin = "git+https://github.com/alire-project/#alire.git@f418890a85f421b20ad00f1f52259c122f883aca"
+#
+#    ['0.6'.depends-on]
+#    aaa = "^1.0.0"
+#    semantic_versioning = "~0.3.2"
+#    simple_logging = "^1.0"
+#
+#['0.5']
+#origin = "git+https://github.com/alire-project/#alire.git@f418890a85f421b20ad00f1f52259c122f883aca"
+#
+#    ['0.5'.depends-on]
+#    semantic_versioning = "~0.3.2"
+#    simple_logging = "^1.0"
+#
+#['0.4']
+#origin = "git+https://github.com/alire-project/#alire.git@219cdcbc5f26efca331400582026c6377ef0f794"
+#
+#    ['0.4'.depends-on]
+#    semantic_versioning = "~0.3.1"
+#    simple_logging = "^1.0"
+#
+#['0.2']
+#origin = "git+https://github.com/alire-project/#alire.git@5ba81ba33dfeb184b2e644ef2996200b5fdd6ae4"
+#
+#    ['0.2'.depends-on]
+#    semantic_versioning = "~0.3"
+#    simple_logging = "^1.0"

--- a/index/al/alr.toml
+++ b/index/al/alr.toml
@@ -4,35 +4,37 @@ licenses = ["GPL 3.0"]
 authors = ["Alejandro R. Mosteo"]
 maintainers = ["alejandro@mosteo.com"]
 
-['0.6']
-origin = "git+https://github.com/alire-project/alr.git@7686e42addf0a341a72383572555c75ad0516a4e"
+# Old versions no longer work due to repo renaming
 
-    ['0.6'.depends-on]
-    alire = "~0.6"
-    ajunitgen = "^1.0.0"
-
-['0.5']
-origin = "git+https://github.com/alire-project/alr.git@d26955fbfd8ef8b301791ab554113af1c6d46365"
-
-    ['0.5'.depends-on]
-    alire = "~0.5"
-    ajunitgen = "^1.0.0"
-
-['0.4']
-origin = "git+https://github.com/alire-project/alr.git@721d111225cf30b9c298ff23587664510f4c4ea1"
-
-    ['0.4'.depends-on]
-    alire = "~0.4"
-    xml_ez_out = "^1.6"
-
-['0.2']
-origin = "git+https://github.com/alire-project/alr.git@481a22aceb07242cabaefedbb41b2d6fe7a8bd1e"
-
-    ['0.2'.depends-on]
-    alire = "~0.2"
-
-['0.1.2']
-origin = "git+https://github.com/alire-project/alr.git@4002536beea8aee12b455077df4dd144b409bde4"
-
-    ['0.1.2'.depends-on]
-    alire = "~0.1.2"
+#['0.6']
+#origin = "git+https://github.com/alire-project/alr.git@7686e42addf0a341a72383572555c75ad0516a4e"
+#
+#    ['0.6'.depends-on]
+#    alire = "~0.6"
+#    ajunitgen = "^1.0.0"
+#
+#['0.5']
+#origin = "git+https://github.com/alire-project/alr.git@d26955fbfd8ef8b301791ab554113af1c6d46365"
+#
+#    ['0.5'.depends-on]
+#    alire = "~0.5"
+#    ajunitgen = "^1.0.0"
+#
+#['0.4']
+#origin = "git+https://github.com/alire-project/alr.git@721d111225cf30b9c298ff23587664510f4c4ea1"
+#
+#    ['0.4'.depends-on]
+#    alire = "~0.4"
+#    xml_ez_out = "^1.6"
+#
+#['0.2']
+#origin = "git+https://github.com/alire-project/alr.git@481a22aceb07242cabaefedbb41b2d6fe7a8bd1e"
+#
+#    ['0.2'.depends-on]
+#    alire = "~0.2"
+#
+#['0.1.2']
+#origin = "git+https://github.com/alire-project/alr.git@4002536beea8aee12b455077df4dd144b409bde4"
+#
+#    ['0.1.2'.depends-on]
+#    alire = "~0.1.2"

--- a/index/ap/apq.toml
+++ b/index/ap/apq.toml
@@ -10,3 +10,7 @@ project-files = ["apq.gpr"]
 
 ['3.2.0']
 origin = "git+https://github.com/alire-project/apq.git@3b5b4b99f528f853e02abf239da7db3d8c9962b4"
+
+    ['3.2.0'.available.'case(compiler)']
+    'gnat-community-2018' = false # Because of -gnat05
+    '...' = true

--- a/index/au/aunit.toml
+++ b/index/au/aunit.toml
@@ -12,5 +12,4 @@ project-files = ["aunit.gpr"]
 
 [2017]
 origin = "git+https://github.com/alire-project/libaunit.git@b66a41ceb35bfc81b9345655c5f46317a57de3b4"
-executables = ["aunit_harness", "run-ppc-elf", "test_liskov",
-               "test_calculator", "math"]
+executables = ["run-ppc-elf"]

--- a/index/gn/gnat.toml
+++ b/index/gn/gnat.toml
@@ -3,7 +3,11 @@ description = "GNAT is a compiler for the Ada programming language"
 licenses = []
 maintainers = ["alejandro@mosteo.com"]
 
-['7.0']
-    ['7.0'.origin.'case(distribution)']
-    'debian|ubuntu' = "native:gnat-7"
+# Until we rework the native package situation, the intention here is to
+# depend on the native compiler, and not in a particular version. Hence,
+# although versions do not match here, we get the intended result.
+
+[0]
+    [0.origin.'case(distribution)']
+    'debian|ubuntu' = "native:gnat"
     '...' = ""

--- a/index/gn/gnatcoll.toml
+++ b/index/gn/gnatcoll.toml
@@ -23,3 +23,7 @@ maintainers = ["alejandro@mosteo.com"]
 origin = "http://mirrors.cdn.adacore.com/art/5b0819dfc7a447df26c27a99"
 archive-name = "gnatcoll-core-gpl-2018-20180524-src.tar.gz"
 project-files = ["gnatcoll-core-gpl-2018-src/gnatcoll.gpr"]
+
+    [2018.available.'case(compiler)']
+    'gnat-community-2018' = true
+    '...' = false

--- a/index/gn/gnatcoll_slim.toml
+++ b/index/gn/gnatcoll_slim.toml
@@ -4,6 +4,8 @@ licenses = ["GPL 3.0"]
 authors = ["AdaCore"]
 maintainers = ["alejandro@mosteo.com"]
 
+project-files = ["gnatcoll.gpr"]
+
     [general.gpr-externals]
     GNATCOLL_ATOMICS = ["intrinsic", "mutex"]
     GNATCOLL_OS = ["windows", "unix", "osx"]
@@ -21,3 +23,7 @@ maintainers = ["alejandro@mosteo.com"]
 
 [20180425]
 origin = "git+https://github.com/alire-project/gnatcoll-core.git@81bc37d7548fe40024eb0f647df65ec42f65443b"
+
+    [20180425.available.'case(compiler)']
+    'gnat-community-2018' = true
+    '...' = false

--- a/index/gn/gnatcoll_strings.toml
+++ b/index/gn/gnatcoll_strings.toml
@@ -4,6 +4,8 @@ licenses = ["GPL 3.0"]
 authors = ["AdaCore"]
 maintainers = ["alejandro@mosteo.com"]
 
+project-files = ["gnatcoll.gpr"]
+
     [general.gpr-externals]
     GNATCOLL_ATOMICS = ["intrinsic", "mutex"]
     GNATCOLL_OS = ["windows", "unix", "osx"]
@@ -11,13 +13,17 @@ maintainers = ["alejandro@mosteo.com"]
     LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
 
     [general.gpr-set-externals]
-    BUILD = "prod"
+    BUILD = "PROD"
     LIBRARY_TYPE = "static-pic"
 
-    [general.gpr-set-externals.GNATCOLL_OS.'case(os)']
-    linux = "unix"
-    macos = "osx"
-    windows = "windows"
+        [general.gpr-set-externals.GNATCOLL_OS.'case(os)']
+        linux = "unix"
+        macos = "osx"
+        windows = "windows"
 
 [20180425]
 origin = "git+https://github.com/alire-project/gnatcoll-core.git@7823e31add7133b9fbc6e037d9986a823e840dc0"
+
+    [20180425.available.'case(compiler)']
+    'gnat-community-2018' = true
+    '...' = false

--- a/index/li/libadacrypt.toml
+++ b/index/li/libadacrypt.toml
@@ -5,11 +5,6 @@ authors = ["Christian Forler"]
 maintainers = ["alejandro@mosteo.com"]
 
 project-files = ["libadacrypt.gpr"]
-executables = ["test-asymmetric_ciphers",
-               "test-big_number",
-               "test-kdf",
-               "test-symmetric_ciphers",
-               "test-tests"]
 
     [general.available.'case(os)']
     linux = true
@@ -28,9 +23,3 @@ executables = ["test-asymmetric_ciphers",
 ['0.8.7']
 origin = "git+https://github.com/alire-project/Ada-Crypto-Library.git@33d15283abbc6d8a51d717de2bd822e026710c0d"
 notes = "It fails self-tests; might be a spurious warning"
-
-    ['0.8.7'.depends-on]
-    aunit = "^2017"
-
-    ['0.8.7'.available.'case(compiler)']
-    'gnat-fsf-7.3|gnat-community-2018' = true

--- a/index/ma/mathpaqs.toml
+++ b/index/ma/mathpaqs.toml
@@ -12,6 +12,10 @@ maintainers = ["alejandro@mosteo.com"]
 origin = "git+https://github.com/svn2github/Mathpaqs.git@0f406899a339b654b247a4017557b0943c431486"
 executables = ["test_discrete_random_simulation"]
 
+    [20180327.available.'case(compiler)']
+    'gnat-community-2018' = false
+    '...' = true
+
 ['20180114']
 origin = "git+https://github.com/svn2github/Mathpaqs.git@c17a6725c4b559ea55b64f0cf3c3660e558777ea"
 executables = [
@@ -22,3 +26,7 @@ executables = [
    "test_generic_real_linear_equations", "test_normal", "test_pareto",
    "test_poisson", "test_qr", "test_random_performance", "test_rsa",
    "test_samples", "test_sparse", "test_u_rand"]
+   
+    [20180114.available.'case(compiler)']
+    'gnat-community-2018' = false
+    '...' = true

--- a/index/pr/pragmarc.toml
+++ b/index/pr/pragmarc.toml
@@ -11,6 +11,14 @@ executables = ["compile_all"]
 origin = "git+https://github.com/alire-project/PragmARC.git@db6c1730fe825f8303c60b48f82db08bd408588d"
 notes = "ISO/IEC 8652:2007 version"
 
+    ['2017.2007.0'.available.'case(compiler)']
+    'gnat-community-2018' = false
+    '...' = true
+
 ['2011.1995.0']
 origin = "git+https://github.com/alire-project/PragmARC.git@34b0e12b5f9aea63408c94cc48ba7a16687c8d76"
 notes = "Ada 95 version"
+
+    ['2011.1995.0'.available.'case(compiler)']
+    'gnat-community-2018' = false
+    '...' = true

--- a/index/rx/rxada.toml
+++ b/index/rx/rxada.toml
@@ -8,5 +8,9 @@ maintainers = ["alejandro@mosteo.com"]
 executables = ["rx-examples-basic", "rx-examples-minimal",
                "rx-examples-tests", "rx-examples-threading"]
 
+project-files = ["rxada.gpr",
+                 "rxada_lib.gpr", 
+                 "rxada_examples.gpr"]
+
 ['0.1.0']
-origin = "hg+https://bitbucket.org/amosteo/rxada@361d4e2ab20a7dcca007e31bf7094d57b13fee6b"
+origin = "git+https://github.com/mosteo/rxada@918a9831b9c0ab7a478442040e06032b5218021a"

--- a/index/te/templates_parser.toml
+++ b/index/te/templates_parser.toml
@@ -20,6 +20,7 @@ maintainers = ["alejandro@mosteo.com"]
 
 ['18.2']
 origin = "git+https://github.com/AdaCore/templates-parser.git@cfb146506fa2fa276e935244021d44e0d834c342"
+available = false # License clash with dependencies
 
     ['18.2'.depends-on]
     xmlada = "^18.2"

--- a/index/xm/xmlada.toml
+++ b/index/xm/xmlada.toml
@@ -5,7 +5,12 @@ authors = ["AdaCore"]
 website = "https://github.com/AdaCore/xmlada"
 maintainers = ["alejandro@mosteo.com"]
 
-project-files = ["distrib/xmlada.gpr"]
+project-files = ["distrib/xmlada.gpr",
+                 "dom/xmlada_dom.gpr",
+                 "input_sources/xmlada_input.gpr",
+                 "sax/xmlada_sax.gpr",
+                 "schema/xmlada_schema.gpr",
+                 "unicode/xmlada_unicode.gpr"]
 
     [general.gpr-externals]
     LIBRARY_TYPE = ["relocatable", "static", "static-pic"]


### PR DESCRIPTION
Mostly:
- Executables that were created by gpr files that were removed (test projects)
- Projects that use -gnat05 in community compiler edition

And a few one-shot ones