### PR TITLE
sdlada: Add post-fetch action

### DIFF
--- a/index/sd/sdlada.toml
+++ b/index/sd/sdlada.toml
@@ -21,6 +21,14 @@ project-files = ["build/gnat/sdlada.gpr"]
     linux = true
     '...' = false
 
+[[general.actions.'case(os)'.linux]]
+type = "post-fetch"
+command = "make -C build/gnat SDL_PLATFORM=linux SDL_MODE=release"
+
+[[general.actions.'case(os)'.windows]]
+type = "post-fetch"
+command = "make -C build/gnat SDL_PLATFORM=windows SDL_MODE=release"
+
 ['2.3.1']
 origin = "https://github.com/Lucretia/sdlada/archive/v2.3.1.tar.gz"
 origin-hashes = ["sha512:786a047fd74f5105eef9d8b3f1ad082b915339cf9da4a2c32f7789dc12005acb2999301e616a67ec0b2a4c084586e812f8d6343dbd33d8bd165ba58a94db16e3"]


### PR DESCRIPTION
SDLAda requires a run of make to generate the SDL.Events.Keyboards package.