### PR TITLE
Fix Basalt license string

### DIFF
--- a/index/ba/basalt.toml
+++ b/index/ba/basalt.toml
@@ -6,5 +6,5 @@ origin-hashes = "sha512:715cb1b41be4425b90adc5404fd4193d97c74980245ef75b09f5986b
 description = "Collection of formally verified building blocks"
 maintainers = ["kliemann@componolit.com"]
 maintainers-logins = ["jklmnn"]
-licenses = ["AGPLv3"]
+licenses = ["AGPL 3.0"]
 


### PR DESCRIPTION
I tried to use Basalt added in #61 but I noticed that the license string was not accepted by alire. I initially failed to notice that only certain license strings are allowed. Also the AGPLv3 is not explicitly stated in the [specification](https://github.com/alire-project/alire/blob/master/doc/catalog-format-spec.rst) but seems to be available in the source code (at least I found it in `src/alire/alire-licensing.ads` when grepping for it).

This PR only fixes the license string ~~but I'd suggest to setup a CI that checks correspondence of package configs with the specifications so that this kind of error can be fixed early~~. Seems you already did that.