### PR TITLE
Add Ada Utility Library definitions

### DIFF
--- a/index/index.toml
+++ b/index/index.toml
@@ -1,1 +1,1 @@
-version = "1.0"
+version = "0.1"

--- a/index/lz/lzmada.toml
+++ b/index/lz/lzmada.toml
@@ -4,15 +4,12 @@ licenses = ["MIT"]
 maintainers = ["Stephane.Carrez@gmail.com"]
 maintainers-logins = ["stcarrez"]
 
-    project-files = ["lzmada.gpr"]
+    project-files = [".alire/lzmada.gpr"]
 
     [general.gpr-externals]
     LZMA_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
     BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
 
-    [[general.actions]]
-    type = "post-fetch"
-    command = ["cp", ".alire/lzmada.gpr", "lzmada.gpr"]
-
 ['1.1.0']
-origin = "git+https://github.com/stcarrez/ada-lzma.git@3e55cdadbb46ba1428ac52a00b403039bd0fcaaa"
+origin = "https://github.com/stcarrez/ada-lzma/archive/1.1.0.tar.gz"
+origin-hashes = ["sha512:1344289480d43e12622c3ae822d9b4a34d927219341eafff2f80151f2ee6613aac6599d3ee46f602869d1f498129fd0607b688951d6cbf97b24b48af2cb44047"]

--- a/index/lz/lzmada.toml
+++ b/index/lz/lzmada.toml
@@ -1,0 +1,18 @@
+[general]
+description = "Ada LZMA Library Binding"
+licenses = ["MIT"]
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+
+    project-files = ["lzmada.gpr"]
+
+    [general.gpr-externals]
+    LZMA_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+    BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
+
+    [[general.actions]]
+    type = "post-fetch"
+    command = ["cp", ".alire/lzmada.gpr", "lzmada.gpr"]
+
+['1.1.0']
+origin = "git+https://github.com/stcarrez/ada-lzma.git@3e55cdadbb46ba1428ac52a00b403039bd0fcaaa"

--- a/index/ut/utilada.toml
+++ b/index/ut/utilada.toml
@@ -1,0 +1,40 @@
+[general]
+description = "Ada Utility Library"
+licenses = ["Apache 2.0"]
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+
+    project-files = [
+        "utilada_core.gpr",
+        "utilada_base.gpr",
+        "utilada_sys.gpr"
+    ]
+
+    [general.gpr-externals]
+    UTIL_OS = ["win32", "win64", "linux32", "linux64", "macos64",
+               "netbsd32", "netbsd64", "freebsd32", "freebsd64"]
+    UTIL_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+    BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
+
+    [general.gpr-set-externals]
+    BUILD = "distrib"
+    UTIL_LIBRARY_TYPE = "static"
+
+    [general.gpr-set-externals.'case(os)'.windows.'case(word_size)']
+    bits-64 = { UTIL_OS = "windows64" }
+    bits-32 = { UTIL_OS = "windows32" }
+
+    [general.gpr-set-externals.'case(os)'.linux.'case(word_size)']
+    bits-64 = { UTIL_OS = "linux64" }
+    bits-32 = { UTIL_OS = "linux32" }
+
+    [general.gpr-set-externals.'case(os)']
+    macos = { UTIL_OS = "macos64" }
+
+    [[general.actions]]
+    type = "post-fetch"
+    command = ["cp", ".alire/utilada_conf.gpr", "."]
+
+['2.0.0']
+origin = "git+https://github.com/stcarrez/ada-util.git@9254d4427f1b5498a1896ee146e3cca61a6913ee"
+

--- a/index/ut/utilada.toml
+++ b/index/ut/utilada.toml
@@ -1,10 +1,11 @@
 [general]
-description = "Ada Utility Library"
+description = "Utility Library with streams, processes, logs, serialization, encoders"
 licenses = ["Apache 2.0"]
 maintainers = ["Stephane.Carrez@gmail.com"]
 maintainers-logins = ["stcarrez"]
 
     project-files = [
+        ".alire/utilada_conf.gpr",
         "utilada_core.gpr",
         "utilada_base.gpr",
         "utilada_sys.gpr"
@@ -31,10 +32,6 @@ maintainers-logins = ["stcarrez"]
     [general.gpr-set-externals.'case(os)']
     macos = { UTIL_OS = "macos64" }
 
-    [[general.actions]]
-    type = "post-fetch"
-    command = ["cp", ".alire/utilada_conf.gpr", "."]
-
 ['2.0.0']
-origin = "git+https://github.com/stcarrez/ada-util.git@9254d4427f1b5498a1896ee146e3cca61a6913ee"
-
+origin = "https://github.com/stcarrez/ada-util/archive/2.0.0.tar.gz"
+origin-hashes = ["sha512:5e0a1f543d903a4d52e7f7fce233f3459e429b81c6c880c9ed6d7e89e0ac202f9394d4d316f3741772972a72c19f5a7ede0230674e2239b300465e0997ddbe64"]

--- a/index/ut/utilada_aws.toml
+++ b/index/ut/utilada_aws.toml
@@ -1,11 +1,11 @@
 [general]
-description = "Utility Library streams with LZMA support"
+description = "Utility Library REST support on top of AWS"
 licenses = ["Apache 2.0"]
 maintainers = ["Stephane.Carrez@gmail.com"]
 maintainers-logins = ["stcarrez"]
 
     project-files = [
-        ".alire/lzma/utilada_lzma.gpr"
+        ".alire/aws/utilada_aws.gpr"
     ]
 
     [general.gpr-externals]
@@ -14,7 +14,6 @@ maintainers-logins = ["stcarrez"]
 
     [general.depends-on]
     utilada = "^2.0.0"
-    lzmada = "^1.1.0"
 
 ['2.0.0']
 origin = "https://github.com/stcarrez/ada-util/archive/2.0.0.tar.gz"

--- a/index/ut/utilada_curl.toml
+++ b/index/ut/utilada_curl.toml
@@ -1,0 +1,23 @@
+[general]
+description = "Ada Utility Library (CURL)"
+licenses = ["Apache 2.0"]
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+
+    project-files = [
+        "utilada_curl.gpr"
+    ]
+
+    [general.gpr-externals]
+    UTIL_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+    BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
+
+    [general.depends-on]
+    utilada = "^2.0.0"
+
+    [[general.actions]]
+    type = "post-fetch"
+    command = ["rm", "-f", "config.gpr", "utilada_core.gpr", "utilada_sys.gpr"]
+
+['2.0.0']
+origin = "git+https://github.com/stcarrez/ada-util.git@9254d4427f1b5498a1896ee146e3cca61a6913ee"

--- a/index/ut/utilada_curl.toml
+++ b/index/ut/utilada_curl.toml
@@ -1,5 +1,5 @@
 [general]
-description = "Ada Utility Library (CURL)"
+description = "Utility Library REST support on top of CURL"
 licenses = ["Apache 2.0"]
 maintainers = ["Stephane.Carrez@gmail.com"]
 maintainers-logins = ["stcarrez"]
@@ -15,9 +15,6 @@ maintainers-logins = ["stcarrez"]
     [general.depends-on]
     utilada = "^2.0.0"
 
-    [[general.actions]]
-    type = "post-fetch"
-    command = ["rm", "-f", "config.gpr", "utilada_core.gpr", "utilada_sys.gpr"]
-
 ['2.0.0']
-origin = "git+https://github.com/stcarrez/ada-util.git@9254d4427f1b5498a1896ee146e3cca61a6913ee"
+origin = "https://github.com/stcarrez/ada-util/archive/2.0.0.tar.gz"
+origin-hashes = ["sha512:5e0a1f543d903a4d52e7f7fce233f3459e429b81c6c880c9ed6d7e89e0ac202f9394d4d316f3741772972a72c19f5a7ede0230674e2239b300465e0997ddbe64"]

--- a/index/ut/utilada_lzma.toml
+++ b/index/ut/utilada_lzma.toml
@@ -1,0 +1,29 @@
+[general]
+description = "Ada Utility Library (LZMA)"
+licenses = ["Apache 2.0"]
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+
+    project-files = [
+        "utilada_lzma.gpr"
+    ]
+
+    [general.gpr-externals]
+    UTIL_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+    BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
+
+    [general.depends-on]
+    utilada = "^2.0.0"
+
+    [[general.actions]]
+    type = "post-fetch"
+    command = ["rm", "-f", "config.gpr", "utilada_core.gpr", "utilada_sys.gpr"]
+
+    [[general.actions]]
+    type = "post-fetch"
+    command = ["cp", ".alire/utilada_lzma.gpr", "."]
+
+['2.0.0']
+origin = "git+https://github.com/stcarrez/ada-util.git@9254d4427f1b5498a1896ee146e3cca61a6913ee"
+
+

--- a/index/ut/utilada_unit.toml
+++ b/index/ut/utilada_unit.toml
@@ -1,11 +1,11 @@
 [general]
-description = "Utility Library streams with LZMA support"
+description = "Utility Library testing framework with Ahven"
 licenses = ["Apache 2.0"]
 maintainers = ["Stephane.Carrez@gmail.com"]
 maintainers-logins = ["stcarrez"]
 
     project-files = [
-        ".alire/lzma/utilada_lzma.gpr"
+        ".alire/unit/utilada_unit.gpr"
     ]
 
     [general.gpr-externals]
@@ -14,7 +14,6 @@ maintainers-logins = ["stcarrez"]
 
     [general.depends-on]
     utilada = "^2.0.0"
-    lzmada = "^1.1.0"
 
 ['2.0.0']
 origin = "https://github.com/stcarrez/ada-util/archive/2.0.0.tar.gz"

--- a/index/ut/utilada_xml.toml
+++ b/index/ut/utilada_xml.toml
@@ -1,0 +1,27 @@
+[general]
+description = "Ada Utility Library (XML)"
+licenses = ["Apache 2.0"]
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+
+    project-files = [
+        "utilada_xml.gpr"
+    ]
+
+    [general.gpr-externals]
+    UTIL_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+    BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
+
+    [general.depends-on]
+    utilada = "^2.0.0"
+
+    [[general.actions]]
+    type = "post-fetch"
+    command = ["rm", "-f", "config.gpr", "utilada_core.gpr", "utilada_sys.gpr"]
+
+    [[general.actions]]
+    type = "post-fetch"
+    command = ["cp", ".alire/utilada_xml.gpr", "utilada_xml.gpr"]
+
+['2.0.0']
+origin = "git+https://github.com/stcarrez/ada-util.git@9254d4427f1b5498a1896ee146e3cca61a6913ee"

--- a/index/ut/utilada_xml.toml
+++ b/index/ut/utilada_xml.toml
@@ -1,11 +1,11 @@
 [general]
-description = "Ada Utility Library (XML)"
+description = "Utility Library serialization with XML/Ada"
 licenses = ["Apache 2.0"]
 maintainers = ["Stephane.Carrez@gmail.com"]
 maintainers-logins = ["stcarrez"]
 
     project-files = [
-        "utilada_xml.gpr"
+        ".alire/xml/utilada_xml.gpr"
     ]
 
     [general.gpr-externals]
@@ -14,14 +14,8 @@ maintainers-logins = ["stcarrez"]
 
     [general.depends-on]
     utilada = "^2.0.0"
-
-    [[general.actions]]
-    type = "post-fetch"
-    command = ["rm", "-f", "config.gpr", "utilada_core.gpr", "utilada_sys.gpr"]
-
-    [[general.actions]]
-    type = "post-fetch"
-    command = ["cp", ".alire/utilada_xml.gpr", "utilada_xml.gpr"]
+    xmlada = "any"
 
 ['2.0.0']
-origin = "git+https://github.com/stcarrez/ada-util.git@9254d4427f1b5498a1896ee146e3cca61a6913ee"
+origin = "https://github.com/stcarrez/ada-util/archive/2.0.0.tar.gz"
+origin-hashes = ["sha512:5e0a1f543d903a4d52e7f7fce233f3459e429b81c6c880c9ed6d7e89e0ac202f9394d4d316f3741772972a72c19f5a7ede0230674e2239b300465e0997ddbe64"]


### PR DESCRIPTION
This pull request defines several crates to allow using some parts of Ada Utility Library
(https://github.com/stcarrez/ada-util).

I try to follow the Debian policy for the GNAT project names and Debian package names.
As such, I'm using the GNAT project name as much as possible as the crate name.

I've managed to avoid using the configure part of ada-util project. I've stored in the
ada-util project several GNAT project files that are almost ready to be used by alire.
The alr tool does a good job at guessing/setting up the platform dependencies that is required for
the utilada project. Other utilada projects don't have much problems.

The pull request adds the following projects:
```
lzmada                Ada LZMA Library Binding                                          
utilada               Ada Utility Library                                               
utilada_curl          Ada Utility Library (CURL)                                        
utilada_lzma          Ada Utility Library (LZMA)                                        
utilada_xml           Ada Utility Library (XML)  
```