### PR TITLE
Add Ada Database Objects 2.0.0 crates

### DIFF
--- a/index/ad/ado.toml
+++ b/index/ad/ado.toml
@@ -1,0 +1,29 @@
+[general]
+description = "Ada Database Objects (Core library)"
+licenses = ["Apache 2.0"]
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+
+    project-files = [
+        "ado.gpr"
+    ]
+
+    [general.gpr-externals]
+    ADO_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+    BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
+
+    [general.depends-on]
+    utilada = "^2.0.0"
+    utilada_xml = "^2.0.0"
+
+    [[general.actions]]
+    type = "post-fetch"
+    command = ["rm", "-f", "config.gpr"]
+
+    [[general.actions]]
+    type = "post-fetch"
+    command = ["cp", ".alire/ado.gpr", "ado.gpr"]
+
+['2.0.0']
+origin = "git+https://github.com/stcarrez/ada-ado.git@3de2eb8ba3dd1cfd765c6118bef50248f457afa1"
+

--- a/index/ad/ado.toml
+++ b/index/ad/ado.toml
@@ -5,7 +5,7 @@ maintainers = ["Stephane.Carrez@gmail.com"]
 maintainers-logins = ["stcarrez"]
 
     project-files = [
-        "ado.gpr"
+        ".alire/ado.gpr"
     ]
 
     [general.gpr-externals]
@@ -20,10 +20,6 @@ maintainers-logins = ["stcarrez"]
     type = "post-fetch"
     command = ["rm", "-f", "config.gpr"]
 
-    [[general.actions]]
-    type = "post-fetch"
-    command = ["cp", ".alire/ado.gpr", "ado.gpr"]
-
 ['2.0.0']
-origin = "git+https://github.com/stcarrez/ada-ado.git@3de2eb8ba3dd1cfd765c6118bef50248f457afa1"
-
+origin = "https://github.com/stcarrez/ada-ado/archive/2.0.0.tar.gz"
+origin-hashes = ["sha512:27870ba6654bccb0a3a4d07e15c021eaa46cff309bba6bb69179c68ba545843a364fba5d78c580a41976a0ee890cca801dfb510c82d442d0c573fea2f8fd0269"]

--- a/index/ad/ado_postgresql.toml
+++ b/index/ad/ado_postgresql.toml
@@ -1,0 +1,29 @@
+[general]
+description = "Ada Database Objects (PostgreSQL)"
+licenses = ["Apache 2.0"]
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+
+    project-files = [
+        "ado_postgresql.gpr"
+    ]
+
+    [general.gpr-externals]
+    ADO_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+    BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
+
+    [general.depends-on]
+    ado = "^2.0.0"
+
+    [[general.actions]]
+    type = "post-fetch"
+    command = ["rm", "-f", "config.gpr"]
+
+    [[general.actions]]
+    type = "post-fetch"
+    command = ["cp", ".alire/ado_postgresql.gpr", "ado_postgresql.gpr"]
+
+['2.0.0']
+origin = "git+https://github.com/stcarrez/ada-ado.git@3de2eb8ba3dd1cfd765c6118bef50248f457afa1"
+
+

--- a/index/ad/ado_postgresql.toml
+++ b/index/ad/ado_postgresql.toml
@@ -5,7 +5,7 @@ maintainers = ["Stephane.Carrez@gmail.com"]
 maintainers-logins = ["stcarrez"]
 
     project-files = [
-        "ado_postgresql.gpr"
+        ".alire/postgresql/ado_postgresql.gpr"
     ]
 
     [general.gpr-externals]
@@ -19,11 +19,6 @@ maintainers-logins = ["stcarrez"]
     type = "post-fetch"
     command = ["rm", "-f", "config.gpr"]
 
-    [[general.actions]]
-    type = "post-fetch"
-    command = ["cp", ".alire/ado_postgresql.gpr", "ado_postgresql.gpr"]
-
 ['2.0.0']
-origin = "git+https://github.com/stcarrez/ada-ado.git@3de2eb8ba3dd1cfd765c6118bef50248f457afa1"
-
-
+origin = "https://github.com/stcarrez/ada-ado/archive/2.0.0.tar.gz"
+origin-hashes = ["sha512:27870ba6654bccb0a3a4d07e15c021eaa46cff309bba6bb69179c68ba545843a364fba5d78c580a41976a0ee890cca801dfb510c82d442d0c573fea2f8fd0269"]

--- a/index/ad/ado_sqlite.toml
+++ b/index/ad/ado_sqlite.toml
@@ -5,7 +5,7 @@ maintainers = ["Stephane.Carrez@gmail.com"]
 maintainers-logins = ["stcarrez"]
 
     project-files = [
-        "ado_sqlite.gpr"
+        ".alire/sqlite/ado_sqlite.gpr"
     ]
 
     [general.gpr-externals]
@@ -19,11 +19,6 @@ maintainers-logins = ["stcarrez"]
     type = "post-fetch"
     command = ["rm", "-f", "config.gpr"]
 
-    [[general.actions]]
-    type = "post-fetch"
-    command = ["cp", ".alire/ado_sqlite.gpr", "ado_sqlite.gpr"]
-
 ['2.0.0']
-origin = "git+https://github.com/stcarrez/ada-ado.git@3de2eb8ba3dd1cfd765c6118bef50248f457afa1"
-
-
+origin = "https://github.com/stcarrez/ada-ado/archive/2.0.0.tar.gz"
+origin-hashes = ["sha512:27870ba6654bccb0a3a4d07e15c021eaa46cff309bba6bb69179c68ba545843a364fba5d78c580a41976a0ee890cca801dfb510c82d442d0c573fea2f8fd0269"]

--- a/index/ad/ado_sqlite.toml
+++ b/index/ad/ado_sqlite.toml
@@ -1,0 +1,29 @@
+[general]
+description = "Ada Database Objects (SQLite)"
+licenses = ["Apache 2.0"]
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+
+    project-files = [
+        "ado_sqlite.gpr"
+    ]
+
+    [general.gpr-externals]
+    ADO_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+    BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
+
+    [general.depends-on]
+    ado = "^2.0.0"
+
+    [[general.actions]]
+    type = "post-fetch"
+    command = ["rm", "-f", "config.gpr"]
+
+    [[general.actions]]
+    type = "post-fetch"
+    command = ["cp", ".alire/ado_sqlite.gpr", "ado_sqlite.gpr"]
+
+['2.0.0']
+origin = "git+https://github.com/stcarrez/ada-ado.git@3de2eb8ba3dd1cfd765c6118bef50248f457afa1"
+
+


### PR DESCRIPTION
This pull request adds the Ada Database Objects library available at https://github.com/stcarrez/ada-ado.

- the 'ado' crate is the core library and does not contain any database driver
- the 'ado_postgresql' crate depends on 'ado' and is the PostgreSQL driver
- the 'ado_sqlite' crate depends on 'ado' and is the SQLite driver

There is missing the 'ado_mysql' crate because the library dependency
is tricky: we may need one of libmysqlclient or libmariadb libaries.
This is supposed to be identified during the configure step of the library.

However, the crate don't run the configure script that are required traditionally by the source library.
Running configure is a real pain and until now I've successfully managed to avoid it...

