### PR TITLE
Add Ada Wiki Engine 1.2.0 crate

### DIFF
--- a/index/wi/wikiada.toml
+++ b/index/wi/wikiada.toml
@@ -21,7 +21,7 @@ maintainers-logins = ["stcarrez"]
 
     [[general.actions]]
     type = "post-fetch"
-    command = ["rm", "config.gpr"]
+    command = ["rm", "-f", "config.gpr"]
 
 ['1.2.0']
 origin = "git+https://github.com/stcarrez/ada-wiki.git@1705a18eb8f8660fca33e4c6b1eebff90bc0f8fe"

--- a/index/wi/wikiada.toml
+++ b/index/wi/wikiada.toml
@@ -1,11 +1,11 @@
 [general]
-description = "Ada Wiki Engine with parser and renderer for several wiki syntaxes"
+description = "Wiki Engine with parser and renderer for several wiki syntaxes"
 licenses = ["Apache 2.0"]
 maintainers = ["Stephane.Carrez@gmail.com"]
 maintainers-logins = ["stcarrez"]
 
     project-files = [
-        "wikiada.gpr"
+        ".alire/wikiada.gpr"
     ]
 
     [general.gpr-externals]
@@ -17,11 +17,8 @@ maintainers-logins = ["stcarrez"]
 
     [[general.actions]]
     type = "post-fetch"
-    command = ["cp", ".alire/wikiada.gpr", "wikiada.gpr"]
-
-    [[general.actions]]
-    type = "post-fetch"
     command = ["rm", "-f", "config.gpr"]
 
 ['1.2.0']
-origin = "git+https://github.com/stcarrez/ada-wiki.git@1705a18eb8f8660fca33e4c6b1eebff90bc0f8fe"
+origin = "https://github.com/stcarrez/ada-wiki/archive/1.2.0.tar.gz"
+origin-hashes = ["sha512:a57d94178f711de0f9a9d708168b5bf38f20213e609a9b0c5124f25dc294ba4d9d524e1a945c393f516eb2ffbce9f0c808083578804e69515214b1c1115208ff"]

--- a/index/wi/wikiada.toml
+++ b/index/wi/wikiada.toml
@@ -1,0 +1,27 @@
+[general]
+description = "Ada Wiki Engine with parser and renderer for several wiki syntaxes"
+licenses = ["Apache 2.0"]
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+
+    project-files = [
+        "wikiada.gpr"
+    ]
+
+    [general.gpr-externals]
+    WIKI_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+    BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
+
+    [general.depends-on]
+    utilada = "^2.0.0"
+
+    [[general.actions]]
+    type = "post-fetch"
+    command = ["cp", ".alire/wikiada.gpr", "wikiada.gpr"]
+
+    [[general.actions]]
+    type = "post-fetch"
+    command = ["rm", "config.gpr"]
+
+['1.2.0']
+origin = "git+https://github.com/stcarrez/ada-wiki.git@1705a18eb8f8660fca33e4c6b1eebff90bc0f8fe"


### PR DESCRIPTION
This adds the 'wikiada' crate to the index.  This library provides
a small Wiki parser, renderer and generator engine.  It uses 'utilada' crate.