### PR TITLE
Add servlet and server faces web libraries

### DIFF
--- a/index/el/elada.toml
+++ b/index/el/elada.toml
@@ -1,0 +1,25 @@
+[general]
+description = "Expression Language Library (JSR245)"
+licenses = ["Apache 2.0"]
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+
+    project-files = [
+        ".alire/elada.gpr"
+    ]
+
+    [general.depends-on]
+    utilada = "^2.0.0"
+
+    [general.gpr-externals]
+    EL_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+    BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
+
+    [[general.actions]]
+    type = "post-fetch"
+    command = ["rm", "-f", "config.gpr"]
+
+['1.7.0']
+origin = "https://github.com/stcarrez/ada-el/archive/1.7.0.tar.gz"
+origin-hashes = ["sha512:86ac5fc839aa91cd9da2681b5fbeed0d41e749d73bf547f7bf4e1172b351d483fb8549deabd63adf688583a990c7af70bd121a39018ba6c34d93f513aa4f588d"]
+

--- a/index/se/security.toml
+++ b/index/se/security.toml
@@ -1,0 +1,25 @@
+[general]
+description = "Security Library for HTTP client and server with OAuth2 support"
+licenses = ["Apache 2.0"]
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+
+    project-files = [
+        ".alire/security.gpr"
+    ]
+
+    [general.gpr-externals]
+    SECURITY_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+    BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
+
+    [general.depends-on]
+    utilada = "^2.0.0"
+    utilada_xml = "^2.0.0"
+
+    [[general.actions]]
+    type = "post-fetch"
+    command = ["rm", "-f", "config.gpr"]
+
+['1.2.1']
+origin = "https://github.com/stcarrez/ada-security/archive/1.2.1.tar.gz"
+origin-hashes = ["sha512:0a064c4c3d4a0953094910dfbf7ca8d85745a815b62d307e0aae0f1de8d84607fcf001557bc31769cdac0103b5fef565d51a41688029666d77545197dd4362c2"]

--- a/index/se/serverfaces.toml
+++ b/index/se/serverfaces.toml
@@ -1,0 +1,26 @@
+[general]
+description = "Web Server Faces JSR 252, JSR 314 and JSR 344"
+licenses = ["Apache 2.0"]
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+
+    project-files = [
+        ".alire/asf.gpr"
+    ]
+
+    [general.gpr-externals]
+    SECURITY_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+    BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
+
+    [general.depends-on]
+    utilada = "^2.0.0"
+    security = "^1.2.1"
+    servletada = "^1.3.0"
+
+    [[general.actions]]
+    type = "post-fetch"
+    command = ["rm", "-f", "config.gpr"]
+
+['1.3.0']
+origin = "https://github.com/stcarrez/ada-asf/archive/1.3.0.tar.gz"
+origin-hashes = ["sha512:74425bce8321e220d97da08131b49c2d1811fe174f16d4e3a4fccb3c244029b736b138a3d008821ba01ca7472152d37709d5eef08d3cccd32a59130c0649b613"]

--- a/index/se/serverfaces_unit.toml
+++ b/index/se/serverfaces_unit.toml
@@ -1,0 +1,27 @@
+[general]
+description = "Web Server Faces JSR 252, JSR 314 and JSR 344 (Testing framework)"
+licenses = ["Apache 2.0"]
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+
+    project-files = [
+        ".alire/unit/asf.gpr"
+    ]
+
+    [general.gpr-externals]
+    SECURITY_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+    BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
+
+    [general.depends-on]
+    utilada = "^2.0.0"
+    security = "^1.2.1"
+    servletada = "^1.3.0"
+    serverfaces = "^1.3.0"
+
+    [[general.actions]]
+    type = "post-fetch"
+    command = ["rm", "-f", "config.gpr"]
+
+['1.3.0']
+origin = "https://github.com/stcarrez/ada-asf/archive/1.3.0.tar.gz"
+origin-hashes = ["sha512:74425bce8321e220d97da08131b49c2d1811fe174f16d4e3a4fccb3c244029b736b138a3d008821ba01ca7472152d37709d5eef08d3cccd32a59130c0649b613"]

--- a/index/se/servletada.toml
+++ b/index/se/servletada.toml
@@ -1,0 +1,25 @@
+[general]
+description = "Web Servlet Library following JSR 154, JSR 315 (Core)"
+licenses = ["Apache 2.0"]
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+
+    project-files = [
+        ".alire/servletada.gpr"
+    ]
+
+    [general.gpr-externals]
+    SERVLET_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+    BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
+
+    [general.depends-on]
+    utilada = "^2.0.0"
+    security = "^1.2.1"
+
+    [[general.actions]]
+    type = "post-fetch"
+    command = ["rm", "-f", "config.gpr"]
+
+['1.3.0']
+origin = "https://github.com/stcarrez/ada-servlet/archive/1.3.0.tar.gz"
+origin-hashes = ["sha512:7ba99a77dea06e058367504b9cd8bf39599f237f09128b1cac1aa55cc067f0380df6e76de374642e89ea1f4a1a4770c1048d40ad7ff5e6f3aaa42415ad5b7082"]

--- a/index/se/servletada_aws.toml
+++ b/index/se/servletada_aws.toml
@@ -1,0 +1,25 @@
+[general]
+description = "Web Servlet Library following JSR 154, JSR 315 (AWS)"
+licenses = ["Apache 2.0"]
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+
+    project-files = [
+        ".alire/aws/servletada_aws.gpr"
+    ]
+
+    [general.gpr-externals]
+    SERVLET_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+    BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
+
+    [general.depends-on]
+    servletada = "^1.3.0"
+    utilada_aws = "^2.0.0"
+
+    [[general.actions]]
+    type = "post-fetch"
+    command = ["rm", "-f", "config.gpr"]
+
+['1.3.0']
+origin = "https://github.com/stcarrez/ada-servlet/archive/1.3.0.tar.gz"
+origin-hashes = ["sha512:7ba99a77dea06e058367504b9cd8bf39599f237f09128b1cac1aa55cc067f0380df6e76de374642e89ea1f4a1a4770c1048d40ad7ff5e6f3aaa42415ad5b7082"]

--- a/index/se/servletada_unit.toml
+++ b/index/se/servletada_unit.toml
@@ -1,0 +1,26 @@
+[general]
+description = "Web Servlet Library following JSR 154, JSR 315 (Testing framework)"
+licenses = ["Apache 2.0"]
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+
+    project-files = [
+        ".alire/unit/servletada_unit.gpr"
+    ]
+
+    [general.gpr-externals]
+    SERVLET_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+    BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
+
+    [general.depends-on]
+    utilada = "^2.0.0"
+    utilada_unit = "^2.0.0"
+    servletada = "^1.3.0"
+
+    [[general.actions]]
+    type = "post-fetch"
+    command = ["rm", "-f", "config.gpr"]
+
+['1.3.0']
+origin = "https://github.com/stcarrez/ada-servlet/archive/1.3.0.tar.gz"
+origin-hashes = ["sha512:7ba99a77dea06e058367504b9cd8bf39599f237f09128b1cac1aa55cc067f0380df6e76de374642e89ea1f4a1a4770c1048d40ad7ff5e6f3aaa42415ad5b7082"]


### PR DESCRIPTION
This pull request adds several projects that help in building web applications.
They depend on utilada projects.

- elada is the EL library required by Ada Servlet and Ada Server Faces,
- security is the library that provides client and server security framework with permissions and OAuth2
- servlet is the Ada servlet library. It does not depend on any web server.
- servlet_aws is the specific binding for the AWS web server
- servlet_unit is a unit test framework that allows to build unit tests (on top of utilada_unit),
- serverfaces is the Ada Server Faces library (which uses servlet and elada),
- serverfaces_unit is a unit test framework that helps writing unit tests (needs servlet_unit).

