### PR TITLE
Workflow to test submitted crate builds

### DIFF
--- a/.github/workflows/build-crate.yml
+++ b/.github/workflows/build-crate.yml
@@ -1,0 +1,71 @@
+name: Build Crate
+
+on:
+  pull_request:
+    paths:
+      - 'index/**.toml'
+
+jobs:
+
+  build:
+    name: Build crate on ${{ matrix.os }}::${{ matrix.tag}}
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: 
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+        tag:
+          - centos-latest-community-2019
+          - community-current          
+          - debian-stable          
+          - ubuntu-lts
+        exclude: # inclusions don't allow to add arrays of values to a scenario
+          - os: macos-latest
+            tag: centos-latest-community-2019
+          - os: macos-latest
+            tag: community-current
+          - os: macos-latest
+            tag: debian-stable
+          - os: windows-latest
+            tag: centos-latest-community-2019
+          - os: windows-latest
+            tag: community-current
+          - os: windows-latest
+            tag: debian-stable
+
+    steps:
+    - name: Check out alire-index
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 3 # Needed to be able to diff and obtain changed files
+
+    - name: Set up GNAT toolchain (FSF)
+      if: matrix.os == 'ubuntu-latest'
+      uses: ada-actions/toolchain@dev
+      with:
+        distrib: fsf # faster install?
+
+    - name: Set up GNAT toolchain (Community)
+      if: matrix.os != 'ubuntu-latest'
+      uses: ada-actions/toolchain@dev
+      with:
+        distrib: community
+
+    - name: Set up `alr`
+      uses: mosteo/setup-alire@exp
+
+    - name: Test crate (Linux)
+      if: matrix.os == 'ubuntu-latest' # docker testing only for linuxes
+      uses: mosteo/actions@docker-run/v1
+      with:
+        image: alire/gnat:${{matrix.tag}}
+        command: scripts/gh-build-crate.sh
+
+    - name: Test crate (Windows/MacOS)
+      if: matrix.os != 'ubuntu-latest' # native testing in Windows/MacOS
+      run: scripts/gh-build-crate.sh
+      shell: bash

--- a/scripts/gh-build-crate.sh
+++ b/scripts/gh-build-crate.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+trap 'echo "ERROR at line ${LINENO} (code: $?)" >&2' ERR
+trap 'echo "Interrupted" >&2 ; exit 1' INT
+
+set -o errexit
+set -o nounset
+
+# get changes from second parent of this merge commit
+COMMIT=`git rev-list --parents -n1 HEAD | cut -f3 -d' '`
+echo COMMIT for diff is $COMMIT
+CHANGES=`git diff-tree --no-commit-id --name-only -r $COMMIT`
+
+# Import the out-of-docker built alr
+export PATH+=:${PWD}/alire/bin
+
+# Configure index
+alr index --name local --add ./index
+
+# Bulk changes for the record
+echo Changed files: $CHANGES
+
+# Test crate
+for file in $CHANGES; do
+
+   if [[ $file == index.toml ]]; then 
+      echo Skipping index metadata file: $file
+      continue
+   fi
+
+   if [[ $file != *.toml ]]; then
+      echo Skipping non-crate file: $file
+      continue
+   fi
+
+   if ! [ -f ./$file ]; then
+      echo Skipping deleted file: $file
+      continue
+   fi
+
+   # Checks passed, this is a crate we must test
+
+   crate=$(basename $file .toml)
+   echo Testing crate: $crate
+
+   # Show info for the record
+   echo PLATFORM-INDEPENDENT CRATE INFO
+   alr show $crate
+   alr show --external $crate
+   alr show --external-detect $crate
+
+   echo PLATFORM-DEPENDENT CRATE INFO
+   alr show --system $crate
+   alr show --external --system $crate
+   alr show --external-detect --system $crate
+
+   if $(alr show $crate --system | grep -q 'Available when: False'); then
+      echo Skipping crate build: UNAVAILABLE on system
+      continue
+   fi
+
+   echo BUILDING CRATE
+   alr get --build -n $crate
+
+   echo LISTING EXECUTABLES
+   cd ${crate}_*
+   alr run --list
+   cd ..
+
+   echo CRATE BUILD ENDED SUCCESSFULLY
+done


### PR DESCRIPTION
A new workflow that attempts to build the last version of a submitted crate on all our CI platforms. If the release is unavailable in a given testing environment it is skipped (this is what we would want from packagers, that they properly describe the availability conditions for a release).

I suspect we have a few crates that can't be built by themselves (they need to be used by a dependent). These will be incorrectly flagged and I guess we should devise some way of dealing with that either in `alr` or the crates themselves. This will raise awareness, at least.