### PR TITLE
update basalt to 0.2.0

### DIFF
--- a/index/ba/basalt.toml
+++ b/index/ba/basalt.toml
@@ -1,3 +1,7 @@
+["0.2.0"]
+origin = "https://github.com/Componolit/basalt/archive/v0.2.0.tar.gz"
+origin-hashes = ["sha512:ecc31fff5a413913a7d6f3ae67107c465bf39772497f15fd7444affa9a7816c4fd7808806ee9630ad4703f1a11613bed1d802f10435d1a850154342549b7dabc"]
+
 ["0.1.0"]
 origin = "https://github.com/Componolit/basalt/archive/v0.1.0.tar.gz"
 origin-hashes = ["sha512:715cb1b41be4425b90adc5404fd4193d97c74980245ef75b09f5986bbe84310d2c90771273076ff70785b2098a582ceabb51a0380857576c0e6614f05df152de"]


### PR DESCRIPTION
 - pure units
 - stack implementation
 - value functions
 - termination proof
 - generic zero copy access procedures for stack and queue