### PR TITLE
Fix availability of sdlada on Windows

### DIFF
--- a/index/sd/sdlada.toml
+++ b/index/sd/sdlada.toml
@@ -18,7 +18,7 @@ project-files = ["build/gnat/sdlada.gpr"]
         linux = { SDL_PLATFORM = "linux" }
 
     [general.available.'case(os)']
-    linux = true
+    'linux | windows' = true
     '...' = false
 
 [[general.actions.'case(os)'.linux]]


### PR DESCRIPTION
Crate was marked unavailable despite being configured to be built on Windows