### PR TITLE
Deal with externals in crate builder check

### DIFF
--- a/.github/workflows/build-crate.yml
+++ b/.github/workflows/build-crate.yml
@@ -8,7 +8,7 @@ on:
 jobs:
 
   build:
-    name: Build crate on ${{ matrix.os }}::${{ matrix.tag}}
+    name: HOST:${{ matrix.os }} DOCK:${{ matrix.tag }}
 
     runs-on: ${{ matrix.os }}
 
@@ -41,7 +41,9 @@ jobs:
     - name: Check out alire-index
       uses: actions/checkout@v2
       with:
-        fetch-depth: 3 # Needed to be able to diff and obtain changed files
+        fetch-depth: 10
+        # Needed to be able to diff and obtain changed files. Changes beyond
+        # that depth are not detected. Should be OK for crate submissions.
 
     - name: Set up GNAT toolchain (FSF)
       if: matrix.os == 'ubuntu-latest'

--- a/scripts/gh-build-crate.sh
+++ b/scripts/gh-build-crate.sh
@@ -6,19 +6,20 @@ trap 'echo "Interrupted" >&2 ; exit 1' INT
 set -o errexit
 set -o nounset
 
-# get changes from second parent of this merge commit
-COMMIT=`git rev-list --parents -n1 HEAD | cut -f3 -d' '`
-echo COMMIT for diff is $COMMIT
-CHANGES=`git diff-tree --no-commit-id --name-only -r $COMMIT`
+# See whats happening
+git log --graph --decorate --pretty=oneline --abbrev-commit --all | head -30
+
+# Detect changes
+CHANGES=$(git diff --name-only HEAD~1)
+
+# Bulk changes for the record
+echo Changed files: $CHANGES
 
 # Import the out-of-docker built alr
 export PATH+=:${PWD}/alire/bin
 
 # Configure index
 alr index --name local --add ./index
-
-# Bulk changes for the record
-echo Changed files: $CHANGES
 
 # Test crate
 for file in $CHANGES; do


### PR DESCRIPTION
New checks to avoid attempting to build the crate when 

- crate has an undetected system dependency
   - since build would likely fail
- crate itself is external and undetected