### PR TITLE
Index make as a system crate

### DIFF
--- a/index/ma/make.toml
+++ b/index/ma/make.toml
@@ -5,6 +5,7 @@ maintainers-logins = ["mosteo"]
 licenses = []
 
 [[external]]
-kind = "version-output"
-version-command = [ "make", "--version" ]
-version-regexp = ".*Make ([\\d\\.]+).*"
+kind = "system"
+
+   [external.origin.'case(distribution)']
+   '...' = ["make"]


### PR DESCRIPTION
It is currently a detectable tool that precludes autoinstallation.

Fixes alire-project/alire#339.