### PR TITLE
* Fixed link to format specification document.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ A crate contains the description of a project, with other metadata,
 and the list of available releases (identified by their
 [semantic version](https://semver.org/)).
 
-The complete specification of such TOML files is available in this [document](https://github.com/alire-project/alire/blob/master/doc/catalog-format-spec.rst).
+The complete specification of such TOML files is available in this [document](https://github.com/alire-project/alire/blob/master/doc/catalog-format-spec.md).
 
 ## New crates and releases
 


### PR DESCRIPTION
CONTRIBUTING.md was still referencing the format specification with an "rst" extension while in the repository it's "md". This commit fixes the link,