### PR TITLE
si_units.toml: remove a test project file from project-files list

### DIFF
--- a/index/si/si_units.toml
+++ b/index/si/si_units.toml
@@ -4,7 +4,7 @@ licenses = ["WTFPL"]
 maintainers = ["vinzent@heisenbug.eu"]
 maintainers-logins = ["Jellix"]
 
-project-files = ["si_units_lib.gpr", "si_units.gpr"]
+project-files = ["si_units_lib.gpr"]
 
 tags=["utilities", "formatting"]
 


### PR DESCRIPTION
The project file is used for testing and is not supposed to be withed by users.

This way si_units is compatible with https://github.com/alire-project/alire/pull/458.