### PR TITLE
Fix crate name extraction in build check script

### DIFF
--- a/scripts/gh-build-crate.sh
+++ b/scripts/gh-build-crate.sh
@@ -45,7 +45,7 @@ for file in $CHANGES; do
    # Checks passed, this is a crate we must test
    is_system=false
 
-   crate=$(basename $file .toml)
+   crate=$(basename $file .toml | cut -f1 -d-)
    echo Testing crate: $crate
 
    # Show info for the record


### PR DESCRIPTION
The new `crate-version.toml` name (instead of `crate.toml`) breaks the script.