### PR TITLE
Detect make from version output

### DIFF
--- a/index/ma/make/make-external.toml
+++ b/index/ma/make/make-external.toml
@@ -6,5 +6,9 @@ maintainers-logins = ["mosteo"]
 
 [[external]]
 kind = "system"
-[external.origin."case(distribution)"]
-"..." = ["make"]
+origin = ["make"]
+
+[[external]]
+kind = "version-output"
+version-command = [ "make", "--version" ]
+version-regexp = ".*Make ([\\d\\.]+).*"

--- a/index/ma/make/make-external.toml
+++ b/index/ma/make/make-external.toml
@@ -6,7 +6,7 @@ maintainers-logins = ["mosteo"]
 
 [[external]]
 kind = "system"
-origin = ["make"]
+origin."case(distribution)"."..." = ["make"]
 
 [[external]]
 kind = "version-output"


### PR DESCRIPTION
This way it is available even in platforms without package manager (macOS).

This was the original reason it was defined like this, that I forgot. We can have both external definitions and the system installer will get called when needed.