### PR TITLE
Fetch full history for detection of changed files

### DIFF
--- a/.github/workflows/build-crate.yml
+++ b/.github/workflows/build-crate.yml
@@ -48,9 +48,11 @@ jobs:
     - name: Check out alire-index
       uses: actions/checkout@v2
       with:
-        fetch-depth: 10
-        # Needed to be able to diff and obtain changed files. Changes beyond
-        # that depth are not detected. Should be OK for crate submissions.
+        fetch-depth: 0
+        # Needed to be able to diff and obtain changed files. Furthermore, we
+        # need the full history or else grafted partial branches confuse the
+        # changed files detectors (in both scripts/gh-build-crate.sh and
+        # check-author action).
 
     - name: Set up GNAT toolchain (FSF)
       if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
It seems that shallow clones use grafted branches that confuse our detectors of changed files. Since our index is unlikely to become humongous, I don't think using full history will be ever a problem.