### PR TITLE
Drop `gpr-set-externals` for `LIBRARY_TYPE`

### DIFF
--- a/index/ze/zeromq_ada/zeromq_ada-4.1.5.toml
+++ b/index/ze/zeromq_ada/zeromq_ada-4.1.5.toml
@@ -23,9 +23,6 @@ libzmq = "any"
 [gpr-externals]
 LIBRARY_TYPE = ["static", "relocatable"]
 
-[gpr-set-externals]
-LIBRARY_TYPE = "static"
-
 [origin]
 url = "https://github.com/persan/zeromq-Ada/archive/4.1.5-20200330.tar.gz"
 hashes = ["sha512:b2a857f77a0d3173b0b57978c2525c99c577512bd80928c8443f8f11a00193c6c0a7301a9c4ee9199338a616c40860917b5194e79f42c90f4bd838cde3ff2222"]


### PR DESCRIPTION
As discussed live on gitter, the LIBRARY_TYPE should never be set
in a library manifest.