### PR TITLE
SDLAda: forbid depending on GNAT CE 2020

### DIFF
--- a/index/sd/sdlada/sdlada-2.3.1.toml
+++ b/index/sd/sdlada/sdlada-2.3.1.toml
@@ -11,6 +11,8 @@ project-files = ["build/gnat/sdlada.gpr"]
 libsdl2 = "^2.0"
 libsdl2_image = "^2.0"
 libsdl2_ttf = "^2.0"
+gnat = "/=2020" # Does not build yet with CE 2020
+
 [[actions."case(os)".linux]]
 type = "post-fetch"
 command = ["make", "-C", "build/gnat", "SDL_PLATFORM=linux", "SDL_MODE=release"]


### PR DESCRIPTION
The current release does not build with this compiler version. There is no later version of `sdlada` that compiles with CE 2020 yet.

This way our tests depending on this crate should skip this compiler version only, and users can know this is an expected shortcoming. Once SDLAda 2.5.4 is released with the pending merges, the issue will be fixed for good.