### PR TITLE
SPAT v1.3.0

### DIFF
--- a/index/sp/spat/spat-1.3.0.toml
+++ b/index/sp/spat/spat-1.3.0.toml
@@ -20,7 +20,7 @@ executables = ["run_spat"]
 [[depends-on]]
 si_units = ">=0.2.0"
 [depends-on."case(toolchain)".system]
-gnatcoll = ">=19 & <2000"
+gnatcoll = ">=19"
 
 [origin]
 commit = "4ad4ab14447ac8cbbedcb8d47f026a66a73551d7"

--- a/index/sp/spat/spat-1.3.0.toml
+++ b/index/sp/spat/spat-1.3.0.toml
@@ -18,7 +18,7 @@ project-files = ["spat.gpr"]
 executables = ["run_spat"]
 
 [[depends-on]]
-si_units = ">=0.2.0"
+si_units = "~0.2"
 [depends-on."case(toolchain)".system]
 gnatcoll = ">=19"
 

--- a/index/sp/spat/spat-1.3.0.toml
+++ b/index/sp/spat/spat-1.3.0.toml
@@ -1,0 +1,28 @@
+description = "SPAT - SPARK Proof Analysis Tool"
+long-description = """
+SPAT - SPARK Proof Analysis Tools
+
+Helper tool to obtain, analyse, sort, and filter timing information about
+`gnatprove` runs (`SPARK` tools).
+"""
+name = "spat"
+version = "1.3.0"
+authors = ["Vinzent \"Jellix\" Saranen"]
+website = "https://github.heisenbug.eu/spat"
+licenses = ["WTFPL"]
+tags = ["spark"]
+
+maintainers = ["vinzent@heisenbug.eu"]
+maintainers-logins = ["Jellix"]
+project-files = ["spat.gpr"]
+executables = ["run_spat"]
+
+[[depends-on]]
+si_units = ">=0.2.0"
+[depends-on."case(toolchain)".system]
+gnatcoll = ">=19 & <2000"
+
+[origin]
+commit = "4ad4ab14447ac8cbbedcb8d47f026a66a73551d7"
+url = "git+https://github.com/HeisenbugLtd/spat.git"
+


### PR DESCRIPTION
Updated SPAT release to SI_Units v0.2.0

That means, one should be able to build SPAT directly from an Alire environment (once #186, and #187 are merged).