### PR TITLE
Add Ada Web Application 2.1.0 crates

### DIFF
--- a/index/aw/awa/awa-2.1.0.toml
+++ b/index/aw/awa/awa-2.1.0.toml
@@ -1,0 +1,76 @@
+description = "Ada Web Application"
+name = "awa"
+version = "2.1.0"
+tags = ["web", "users", "jobs", "wiki", "framework", "storage", "blog"]
+website = "https://gitlab.com/stcarrez/ada-awa"
+
+licenses = ["Apache 2.0"]
+authors = ["Stephane.Carrez@gmail.com"]
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+long-description = """
+
+[![Build Status](https://img.shields.io/jenkins/s/https/jenkins.vacs.fr/Bionic-AWA.svg)](https://jenkins.vacs.fr/job/Bionic-AWA/)
+[![Test Status](https://img.shields.io/jenkins/t/https/jenkins.vacs.fr/Bionic-AWA.svg)](https://jenkins.vacs.fr/job/Bionic-AWA/)
+[![codecov](https://codecov.io/gh/stcarrez/ada-awa/branch/master/graph/badge.svg)](https://codecov.io/gh/stcarrez/ada-awa)
+[![Documentation Status](https://readthedocs.org/projects/ada-awa/badge/?version=latest)](https://ada-awa.readthedocs.io/en/latest/?badge=latest)
+
+Ada Web Application is a framework to build a Web Application in Ada 2012.
+The framework provides several ready to use and extendable modules that are common
+to many web application.  This includes the login, authentication, users, permissions,
+managing comments, tags, votes, documents, images.  It provides a complete blog,
+question and answers and a wiki module.
+
+AWA simplifies the Web Application development by taking care of user management with
+Google+, Facebook authentication and by providing the foundations on top of which you
+can construct your own application.  AWA provides a powerful permission management
+that gives flexibility to applications to grant access and protect your user's resources.
+
+![AWA Features](https://github.com/stcarrez/ada-awa/wiki/images/awa-features.png)
+
+# Documentation
+
+The Ada Web Application programmer's guide describes how to setup the framework,
+how you can setup and design your first web application with it,
+and it provides detailed description of AWA components:
+
+  * [Ada Web Application programmer's guide](https://ada-awa.readthedocs.io/en/latest/) [PDF](https://github.com/stcarrez/ada-awa/blob/master/awa/docs/awa-book.pdf)
+  * [Ada Database Objects Programmer's Guide](https://ada-ado.readthedocs.io/en/latest/)
+  * [Ada Security Programmer's Guide](https://ada-security.readthedocs.io/en/latest/)
+  * [Ada Utility Library Programmer's Guide](https://ada-util.readthedocs.io/en/latest/intro/)
+
+"""
+
+project-files = [
+".alire/awa_blogs.gpr", ".alire/awa.gpr", ".alire/awa_settings.gpr", ".alire/awa_wikis.gpr",
+".alire/awa_changelogs.gpr", ".alire/awa_images.gpr", ".alire/awa_setup.gpr", ".alire/awa_workspaces.gpr",
+".alire/awa_comments.gpr", ".alire/awa_jobs.gpr", ".alire/awa_storages.gpr",
+".alire/awa_counters.gpr", ".alire/awa_mail.gpr", ".alire/awa_tags.gpr",
+".alire/awa_countries.gpr", ".alire/awa_questions.gpr", ".alire/awa_votes.gpr"
+]
+
+[[depends-on]]
+utilada = "^2.3.0"
+utilada_xml = "^2.3.0"
+utilada_aws = "^2.3.0"
+ado = "^2.1.1"
+wikiada = "^1.3.0"
+elada = "^1.8.1"
+security = "^1.3.1"
+serverfaces = "^1.4.1"
+servletada = "^1.5.0"
+servletada_aws = "^1.5.0"
+keystoreada = "^1.2.1"
+
+[[actions]]
+type = "post-fetch"
+command = ["gnatprep", "-DHAVE_AWS=yes", "awa/plugins/awa-mail/src/awa-mail-clients-factory.gpb", "awa/plugins/awa-mail/src/awa-mail-clients-factory.adb"]
+
+[gpr-externals]
+AWA_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
+
+[origin]
+commit = "5d65c67e2206f98ebc96aff104859006ffa00e58"
+url = "git+https://github.com/stcarrez/ada-awa.git"
+

--- a/index/aw/awa_unit/awa_unit-2.1.0.toml
+++ b/index/aw/awa_unit/awa_unit-2.1.0.toml
@@ -1,0 +1,43 @@
+description = "Ada Web Application (Testing framework)"
+name = "awa_unit"
+version = "2.1.0"
+tags = ["web", "users", "jobs", "framework", "testing"]
+website = "https://gitlab.com/stcarrez/ada-awa"
+
+licenses = ["Apache 2.0"]
+authors = ["Stephane.Carrez@gmail.com"]
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+long-description = """
+
+[![Build Status](https://img.shields.io/jenkins/s/https/jenkins.vacs.fr/Bionic-AWA.svg)](https://jenkins.vacs.fr/job/Bionic-AWA/)
+[![Test Status](https://img.shields.io/jenkins/t/https/jenkins.vacs.fr/Bionic-AWA.svg)](https://jenkins.vacs.fr/job/Bionic-AWA/)
+[![codecov](https://codecov.io/gh/stcarrez/ada-awa/branch/master/graph/badge.svg)](https://codecov.io/gh/stcarrez/ada-awa)
+[![Documentation Status](https://readthedocs.org/projects/ada-awa/badge/?version=latest)](https://ada-awa.readthedocs.io/en/latest/?badge=latest)
+
+Ada Web Application is a framework to build a Web Application in Ada 2012.
+The framework provides several ready to use and extendable modules that are common
+to many web application.  This includes the login, authentication, users, permissions,
+managing comments, tags, votes, documents, images.  It provides a complete blog,
+question and answers and a wiki module.
+
+This library provides a testing framework on top of AWA top help implementing
+unit tests for AWA applications.
+
+"""
+
+project-files = [".alire/unit/awaunit.gpr"]
+
+[[depends-on]]
+awa = "^2.1.0"
+serverfaces_unit = "^1.4.1"
+servletada_unit = "^1.5.0"
+
+[gpr-externals]
+AWA_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
+
+[origin]
+commit = "5d65c67e2206f98ebc96aff104859006ffa00e58"
+url = "git+https://github.com/stcarrez/ada-awa.git"
+


### PR DESCRIPTION
I've made a new release of AWA and this pull request provides two crates for AWA.

awa: the main AWA framework
awa_unit: a unit testing framework for AWA applications
