### PR TITLE
Fix spurious detection of alire.toml during build test

### DIFF
--- a/scripts/gh-build-crate.sh
+++ b/scripts/gh-build-crate.sh
@@ -18,6 +18,10 @@ echo Changed files: $CHANGES
 # Import the out-of-docker built alr
 export PATH+=:${PWD}/alire/bin
 
+# Change to a new testing folder to avoid spurious detection of ./alire/alire.toml
+mkdir testdir
+cd testdir
+
 # Show alr metadata
 alr version
 


### PR DESCRIPTION
An "old style" manifest at `./alire/alire.toml` is being detected now that the alire repo contains such a file. This confuses the alr running in the parent folder, as `alire` is interpreted as the workspace cache folder.

The detection is correct in the sense that the file is really there (where we build alr), but it is not an old manifest but the proper manifest of the alire repo. This is an unexpected and unwanted interaction that should go away once the check
for old manifests is removed. For now, it's simpler to just do the tests in a clean folder.