### PR TITLE
Second fix for spurious alire.toml detection

### DIFF
--- a/.github/workflows/build-crate.yml
+++ b/.github/workflows/build-crate.yml
@@ -19,6 +19,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
         tag:
+          - arch-rolling
           - centos-latest-community-latest
           - community-current          
           - debian-stable          
@@ -28,6 +29,8 @@ jobs:
           - os: ubuntu-latest
             tag: ""
           - os: macos-latest
+            tag: arch-rolling
+          - os: macos-latest
             tag: centos-latest-community-latest
           - os: macos-latest
             tag: community-current
@@ -35,6 +38,8 @@ jobs:
             tag: debian-stable
           - os: macos-latest
             tag: ubuntu-lts
+          - os: windows-latest
+            tag: arch-rolling
           - os: windows-latest
             tag: centos-latest-community-latest
           - os: windows-latest
@@ -67,7 +72,7 @@ jobs:
         distrib: community
 
     - name: Set up `alr`
-      uses: mosteo/setup-alire@exp
+      uses: alire-project/setup-alire@latest-stable
 
     - name: Test crate (Linux)
       if: matrix.os == 'ubuntu-latest' # docker testing only for linuxes
@@ -75,10 +80,11 @@ jobs:
       with:
         image: alire/gnat:${{matrix.tag}}
         command: scripts/gh-build-crate.sh
+        params: -v ${{ github.workspace }}/alire_install/bin/alr:/usr/bin/alr
 
     - name: Set up msys2 (Windows)
       if: matrix.os == 'windows-latest'
-      run: ./alire/bin/alr --non-interactive version
+      run: ./alire_install/bin/alr --non-interactive version
 
     - name: Install tar from msys2 (Windows) # Git tar in Actions VM does not seem to work)
       if: matrix.os == 'windows-latest'

--- a/scripts/gh-build-crate.sh
+++ b/scripts/gh-build-crate.sh
@@ -15,13 +15,6 @@ CHANGES=$(git diff --name-only HEAD~1)
 # Bulk changes for the record
 echo Changed files: $CHANGES
 
-# Import the out-of-docker built alr
-export PATH+=:${PWD}/alire/bin
-
-# Change to a new testing folder to avoid spurious detection of ./alire/alire.toml
-mkdir testdir
-cd testdir
-
 # Show alr metadata
 alr version
 


### PR DESCRIPTION
The fix in #201 was not complete. This one should work, as it's been fully tested in mosteo/alire-index#11.

As part of the fix, now we test with alr stable instead of rebuilding from master.

Took the opportunity to add Arch to the list of tested platforms.