### PR TITLE
Move from `dev` to `ce2020` Ada toolchain action

### DIFF
--- a/.github/workflows/build-crate.yml
+++ b/.github/workflows/build-crate.yml
@@ -61,13 +61,13 @@ jobs:
 
     - name: Set up GNAT toolchain (FSF)
       if: matrix.os == 'ubuntu-latest'
-      uses: ada-actions/toolchain@dev
+      uses: ada-actions/toolchain@ce2020
       with:
         distrib: fsf # faster install?
 
     - name: Set up GNAT toolchain (Community)
       if: matrix.os != 'ubuntu-latest'
-      uses: ada-actions/toolchain@dev
+      uses: ada-actions/toolchain@ce2020
       with:
         distrib: community
 


### PR DESCRIPTION
`dev` contains obsolete nodejs modules and causes the workflow to fail.