### PR TITLE
Add pkgconf for arch distribution to pkg_config

### DIFF
--- a/index/pk/pkg_config/pkg_config-external.toml
+++ b/index/pk/pkg_config/pkg_config-external.toml
@@ -8,4 +8,5 @@ maintainers-logins = ["Fabien-Chouteau"]
 kind = "system"
 [external.origin."case(distribution)"]
 "debian|ubuntu" = ["pkg-config"]
+arch = ["pkgconf"]
 msys2 = ["mingw-w64-x86_64-pkg-config"]


### PR DESCRIPTION
Arch Linux provides only core/pkgconf to provide pkg-config.