### PR TITLE
Added new crate mb_accel

### DIFF
--- a/index/mb/mb_accel/mb_accel-0.0.1.toml
+++ b/index/mb/mb_accel/mb_accel-0.0.1.toml
@@ -1,0 +1,23 @@
+name = "mb_accel"
+description = "Detects the accelerometer used in the micro:bit board."
+licenses = ["BSD 3-Clauses"]
+
+version = "0.0.1"
+
+authors = ["Karsten Lüth"]
+maintainers = ["Karsten Lüth <kl@kloc-consulting.de>"]
+maintainers-logins = ["KLOC-Karsten"]
+
+tags = [
+  "embedded",
+  "nostd",
+]
+
+[[depends-on]]
+hal = "^0.1.0"
+
+
+[origin]
+commit = "07676fdbcc11f3d367b743f00e95a48424fce43c"
+url = "git+https://github.com/KLOC-Karsten/mb_accel.git"
+


### PR DESCRIPTION
Added a new crate mb_accel (accelerometer detector for the micro:bit board). 