### PR TITLE
Main workflow: check no unknown env values in index

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,9 @@ jobs:
 
     - run: alr index --add=. --name=local_index
 
+    # Check index contents for unknown config variables
+    - run: alr index --check
+
     - run: alr index --update-all 
 
     - run: alr search --crates


### PR DESCRIPTION
Fixes https://github.com/alire-project/alire/issues/659. Since https://github.com/alire-project/alire/pull/656 a user could sneak in unknown environment values if manually packaging for a "future" platform.