### PR TITLE
Replace wrong 'word_size' with 'word-size'

### DIFF
--- a/index/ut/utilada/utilada-2.0.0.toml
+++ b/index/ut/utilada/utilada-2.0.0.toml
@@ -17,18 +17,18 @@ UTIL_OS = ["win32", "win64", "linux32", "linux64", "macos64", "netbsd32", "netbs
 [gpr-set-externals]
 BUILD = "distrib"
 UTIL_LIBRARY_TYPE = "static"
-[gpr-set-externals."case(os)".linux."case(word_size)".bits-32]
+[gpr-set-externals."case(os)".linux."case(word-size)".bits-32]
 UTIL_OS = "linux32"
 
-[gpr-set-externals."case(os)".linux."case(word_size)".bits-64]
+[gpr-set-externals."case(os)".linux."case(word-size)".bits-64]
 UTIL_OS = "linux64"
 
 [gpr-set-externals."case(os)".macos]
 UTIL_OS = "macos64"
-[gpr-set-externals."case(os)".windows."case(word_size)".bits-32]
+[gpr-set-externals."case(os)".windows."case(word-size)".bits-32]
 UTIL_OS = "windows32"
 
-[gpr-set-externals."case(os)".windows."case(word_size)".bits-64]
+[gpr-set-externals."case(os)".windows."case(word-size)".bits-64]
 UTIL_OS = "windows64"
 
 [origin]

--- a/index/ut/utilada/utilada-2.1.0.toml
+++ b/index/ut/utilada/utilada-2.1.0.toml
@@ -17,18 +17,18 @@ UTIL_OS = ["win32", "win64", "linux32", "linux64", "macos64", "netbsd32", "netbs
 [gpr-set-externals]
 BUILD = "distrib"
 UTIL_LIBRARY_TYPE = "static"
-[gpr-set-externals."case(os)".linux."case(word_size)".bits-32]
+[gpr-set-externals."case(os)".linux."case(word-size)".bits-32]
 UTIL_OS = "linux32"
 
-[gpr-set-externals."case(os)".linux."case(word_size)".bits-64]
+[gpr-set-externals."case(os)".linux."case(word-size)".bits-64]
 UTIL_OS = "linux64"
 
 [gpr-set-externals."case(os)".macos]
 UTIL_OS = "macos64"
-[gpr-set-externals."case(os)".windows."case(word_size)".bits-32]
+[gpr-set-externals."case(os)".windows."case(word-size)".bits-32]
 UTIL_OS = "windows32"
 
-[gpr-set-externals."case(os)".windows."case(word_size)".bits-64]
+[gpr-set-externals."case(os)".windows."case(word-size)".bits-64]
 UTIL_OS = "windows64"
 
 [origin]


### PR DESCRIPTION
The old parser for some reason accepted both, when the catalog spec always uses `word-size`.