### PR TITLE
Add glfw for arch and msys2 distributions to libglfw3

### DIFF
--- a/index/li/libglfw3/libglfw3-external.toml
+++ b/index/li/libglfw3/libglfw3-external.toml
@@ -6,4 +6,7 @@ maintainers-logins = ["mosteo"]
 
 [[external]]
 kind = "system"
-origin = ["libglfw3-dev"]
+[external.origin."case(distribution)"]
+"debian|ubuntu" = ["libglfw3-dev"]
+arch = ["glfw"]
+msys2 = ["mingw-w64-x86_64-glfw"]


### PR DESCRIPTION
Not sure the package name for msys2 is correct. @Fabien-Chouteau can you confirm?