### PR TITLE
Added raspberry_bsp package

### DIFF
--- a/index/ra/raspberry_bsp/raspberry_bsp-1.0.0.toml
+++ b/index/ra/raspberry_bsp/raspberry_bsp-1.0.0.toml
@@ -1,0 +1,16 @@
+name = "raspberry_bsp"
+description = "Board Support package for Raspberry PI v1, v2 and B+"
+version = "1.0.0"
+
+authors = ["Tama McGlinn"]
+maintainers = ["Tama McGlinn <t.mcglinn@gmail.com>"]
+maintainers-logins = ["TamaMcGlinn"]
+
+licenses = "MIT"
+tags = ["raspberry", "pi"]
+website = "https://github.com/TamaMcGlinn/ada_raspio"
+
+[origin]
+commit = "a15c773223e31c3ba97dc806897ab1feec2ff5a3"
+url = "git+https://github.com/TamaMcGlinn/ada_raspio.git"
+

--- a/index/ra/raspberry_bsp/raspberry_bsp-1.0.0.toml
+++ b/index/ra/raspberry_bsp/raspberry_bsp-1.0.0.toml
@@ -14,3 +14,5 @@ website = "https://github.com/TamaMcGlinn/ada_raspio"
 commit = "a15c773223e31c3ba97dc806897ab1feec2ff5a3"
 url = "git+https://github.com/TamaMcGlinn/ada_raspio.git"
 
+[available."case(os)"]
+windows = false


### PR DESCRIPTION
Hi Alex,

The package itself works well enough for a 1.0 release, as you can blink LEDs and access buttons on the raspberry pi.
However, it's unclear how to add this to alire, since you have modified the release distribution method heavily since writing the Contributing.md guide. That still says to make a .tar.gz and get it's hash, but I think you support direct commit hashes now. It also says:

> Note that, as of this writing (Dec 2019), only development branches exist, until the first stable release of alr is made.

So it's also not clear how to decide between these two branches. The stability of the alr tool itself doesn't seem to have any bearing on the stability of packages.

Currently, I get this error:

> error: Malformed shelf folder name: /home/tama/.config/alire/indexes/community/repo/index

Finally, I would strongly recommend you allow the opening of issues on the alire-index project itself. I am sure someone would have already noted regarding your Contributing.md guide much earlier, if it were possible to notify you of that without a pull request.