### PR TITLE
Add initial slip version

### DIFF
--- a/index/sl/slip/slip-0.0.1.toml
+++ b/index/sl/slip/slip-0.0.1.toml
@@ -1,0 +1,16 @@
+name = "slip"
+version = "0.0.1"
+description = "SLIP Protocol Implementation"
+licenses = "MIT"
+
+authors = [ "Biser Milanov", ]
+maintainers = [ "bmilanov11@gmail.com", ]
+maintainers-logins = [ "bmilanov", ]
+website = "https://gitlab.com/bmilanov/slip"
+
+tags = [ "embedded", "protocols", "spark" ]
+
+[origin]
+commit = "b99d32df8530b4ef45a2c79c4bfb918b3a76710a"
+url = "git+https://gitlab.com/bmilanov/slip.git"
+


### PR DESCRIPTION
Hello!

Proposing to add my project to the index -- a SLIP implementation in Ada / SPARK2014.

The project: https://gitlab.com/bmilanov/slip

The protocol: https://en.wikipedia.org/wiki/Serial_Line_Internet_Protocol

Meant to be used in embedded projects, but not exclusively.

Aim is to be SPARK-verified and Zero Footprint RTS compatible.