### PR TITLE
Fix slip license

### DIFF
--- a/index/sl/slip/slip-0.0.1.toml
+++ b/index/sl/slip/slip-0.0.1.toml
@@ -1,7 +1,7 @@
 name = "slip"
 version = "0.0.1"
 description = "SLIP Protocol Implementation"
-licenses = "MIT"
+licenses = "BSD-3-Clause"
 
 authors = [ "Biser Milanov", ]
 maintainers = [ "bmilanov11@gmail.com", ]


### PR DESCRIPTION
Correct the crate license, as it is in the project repository.

It is an issue that the "licenses" key in the alire.toml for version 0.0.1 inside the project repository is also "MIT"?

https://gitlab.com/bmilanov/slip/-/blob/0.0.1/alire.toml#L4

I have pushed a fix, but unless I rebase, 0.0.1 will stay with 'MIT' in the TOML file.