### PR TITLE
Openglada: Correct libx11 version

### DIFF
--- a/index/li/libx11/libx11-external.toml
+++ b/index/li/libx11/libx11-external.toml
@@ -7,4 +7,5 @@ maintainers-logins = ["mosteo"]
 [[external]]
 kind = "system"
 [external.origin."case(distribution)"]
+"arch" = ["libx11"]
 "debian|ubuntu" = ["libx11-dev"]

--- a/index/op/openglada/openglada-0.6.0.toml
+++ b/index/op/openglada/openglada-0.6.0.toml
@@ -19,8 +19,11 @@ libx11 = "^1"
 Auto_Exceptions = ["enabled", "disabled"]
 GLFW_Version = ["2", "3"]
 Mode = ["debug", "release"]
-[gpr-set-externals."case(os)".linux]
-Windowing_System = "x11"
+
+[gpr-set-externals."case(os)"]
+linux = { Windowing_System = "x11" }
+macos = { Windowing_System = "quartz" }
+windows = { Windowing_System = "windows" }
 
 [origin]
 url = "https://github.com/flyx/OpenGLAda/archive/v0.6.tar.gz"

--- a/index/op/openglada/openglada-0.6.0.toml
+++ b/index/op/openglada/openglada-0.6.0.toml
@@ -10,8 +10,8 @@ maintainers-logins = ["flyx"]
 project-files = ["opengl.gpr", "opengl-glfw.gpr", "opengl-soil.gpr", "opengl-test.gpr"]
 
 [[depends-on]]
-[depends-on."case(os)".linux]
 gnat = "<8"
+[depends-on."case(os)".linux]
 libglfw3 = "^3"
 libx11 = "^1"
 

--- a/index/op/openglada/openglada-0.6.0.toml
+++ b/index/op/openglada/openglada-0.6.0.toml
@@ -11,6 +11,7 @@ project-files = ["opengl.gpr", "opengl-glfw.gpr", "opengl-soil.gpr", "opengl-tes
 
 [[depends-on]]
 [depends-on."case(os)".linux]
+gnat = "<8"
 libglfw3 = "^3"
 libx11 = "^1"
 

--- a/index/op/openglada/openglada-0.6.0.toml
+++ b/index/op/openglada/openglada-0.6.0.toml
@@ -12,7 +12,7 @@ project-files = ["opengl.gpr", "opengl-glfw.gpr", "opengl-soil.gpr", "opengl-tes
 [[depends-on]]
 [depends-on."case(os)".linux]
 libglfw3 = "^3"
-libx11 = "^2"
+libx11 = "^1"
 
 [gpr-externals]
 Auto_Exceptions = ["enabled", "disabled"]


### PR DESCRIPTION
I tried to install openglada, but it fails due to the libx11 dependency. As far as I can tell the most recent release of libx11 is 1.7.0 in November 2020, and there is no version 2. This lowers the dependency to version 1. I'm guessing that this worked for someone originally as the Ubuntu package oddly has `2:` prefixed at the start. On Arch (or most other distro's) that give the actual version this is breaking.

I don't know how to locally test an Alire package, so this is a change by inspection, and not locally tested as I'm not sure how to test it.