### PR TITLE
added external libfreetype

### DIFF
--- a/index/li/libfreetype/libfreetype-external.toml
+++ b/index/li/libfreetype/libfreetype-external.toml
@@ -9,4 +9,4 @@ kind = "system"
 [external.origin."case(distribution)"]
 "debian|ubuntu" = ["libfreetype6-dev"]
 arch = ["freetype2"]
-msys2 = ["mingw-w64-freetype"]
+msys2 = ["mingw-w64-x86_64-freetype"]

--- a/index/li/libfreetype/libfreetype-external.toml
+++ b/index/li/libfreetype/libfreetype-external.toml
@@ -1,0 +1,12 @@
+description = "A freely available software library to render fonts"
+name = "libfreetype"
+
+maintainers = ["contact@flyx.org"]
+maintainers-logins = ["flyx"]
+
+[[external]]
+kind = "system"
+[external.origin."case(distribution)"]
+"debian|ubuntu" = ["libfreetype6-dev"]
+arch = ["freetype2"]
+msys2 = ["mingw-w64-freetype"]


### PR DESCRIPTION
This is needed as a dependency of OpenGLAda's text rendering facilities.

I am not entirely sure whether the msys2 name should be `mingw-w64-freetype` (base package) or `mingw-w64-x86_64-freetype` (architecture-specific package) since I have no experience with pacman.