### PR TITLE
OpenGLAda 0.9.0

### DIFF
--- a/index/op/openglada/openglada-0.9.0.toml
+++ b/index/op/openglada/openglada-0.9.0.toml
@@ -7,6 +7,7 @@ licenses = "MIT"
 maintainers = ["Felix Krause <contact@flyx.org>"]
 maintainers-logins = ["flyx"]
 project-files = ["opengl.gpr"]
+tags = ["opengl", "binding", "rendering", "graphics"]
 
 [[depends-on]]
 [depends-on."case(os)".linux]

--- a/index/op/openglada/openglada-0.9.0.toml
+++ b/index/op/openglada/openglada-0.9.0.toml
@@ -1,0 +1,29 @@
+name = "openglada"
+description = "Thick Ada binding for OpenGL"
+version = "0.9.0"
+website = "http://flyx.github.io/OpenGLAda/"
+authors = ["Felix Krause"]
+licenses = "MIT"
+maintainers = ["Felix Krause <contact@flyx.org>"]
+maintainers-logins = ["flyx"]
+project-files = ["opengl.gpr"]
+
+[[depends-on]]
+[depends-on."case(os)".linux]
+libx11 = "^1"
+
+[gpr-externals]
+Auto_Exceptions = ["enabled", "disabled"]
+Mode = ["debug", "release"]
+
+[gpr-set-externals."case(os)"]
+linux = { Windowing_System = "x11" }
+macos = { Windowing_System = "quartz" }
+windows = { Windowing_System = "windows" }
+
+[origin]
+hashes = [
+"sha512:4deb7effa92ea06c1fc9595700223b8169a85c15c4caf78221d2cfa95205260b5ba6d132d070b3f25d07549a6c9a8cde3b6405631a7d1ff487af8292c44a10e2",
+]
+url = "https://github.com/flyx/OpenGLAda/releases/download/v0.9.0/openglada-0.9.0.tgz"
+

--- a/index/op/openglada_glfw/openglada_glfw-0.9.0.toml
+++ b/index/op/openglada_glfw/openglada_glfw-0.9.0.toml
@@ -7,6 +7,7 @@ licenses = "MIT"
 maintainers = ["Felix Krause <contact@flyx.org>"]
 maintainers-logins = ["flyx"]
 project-files = ["opengl-glfw.gpr"]
+tags = ["opengl", "glfw", "binding", "gui"]
 
 [[depends-on]]
 openglada = "~0.9.0"

--- a/index/op/openglada_glfw/openglada_glfw-0.9.0.toml
+++ b/index/op/openglada_glfw/openglada_glfw-0.9.0.toml
@@ -1,0 +1,20 @@
+name = "openglada_glfw"
+description = "GLFW binding for use with OpenGLAda"
+version = "0.9.0"
+website = "http://flyx.github.io/OpenGLAda/"
+authors = ["Felix Krause"]
+licenses = "MIT"
+maintainers = ["Felix Krause <contact@flyx.org>"]
+maintainers-logins = ["flyx"]
+project-files = ["opengl-glfw.gpr"]
+
+[[depends-on]]
+openglada = "~0.9.0"
+libglfw3 = "^3"
+
+[origin]
+hashes = [
+"sha512:fc25165caf510898d8c804b0ca4d8f763d49e0bd144ac70a2547f935ee90804b6ea5a1389eee08bb5528546f87eedb5b4e5884360a3a562a57338acea95f0e91",
+]
+url = "https://github.com/flyx/OpenGLAda/releases/download/v0.9.0/openglada_glfw-0.9.0.tgz"
+

--- a/index/op/openglada_images/openglada_images-0.9.0.toml
+++ b/index/op/openglada_images/openglada_images-0.9.0.toml
@@ -7,6 +7,7 @@ licenses = "MIT"
 maintainers = ["Felix Krause <contact@flyx.org>"]
 maintainers-logins = ["flyx"]
 project-files = ["opengl-images.gpr"]
+tags = ["opengl", "rendering", "graphics"]
 
 [[depends-on]]
 gid = "^9.0.0"

--- a/index/op/openglada_images/openglada_images-0.9.0.toml
+++ b/index/op/openglada_images/openglada_images-0.9.0.toml
@@ -1,0 +1,20 @@
+name = "openglada_images"
+description = "Image loading library for OpenGLAda"
+version = "0.9.0"
+website = "http://flyx.github.io/OpenGLAda/"
+authors = ["Felix Krause"]
+licenses = "MIT"
+maintainers = ["Felix Krause <contact@flyx.org>"]
+maintainers-logins = ["flyx"]
+project-files = ["opengl-images.gpr"]
+
+[[depends-on]]
+gid = "^9.0.0"
+openglada = "~0.9.0"
+
+[origin]
+hashes = [
+"sha512:b50ef8e7efb037d23d698f8af470a8a715571348f734411acecaa58e48b2edafe06c5c1a395c616650222ad3a183ead952d89ffebf6be72d11d7fefe1c944e8d",
+]
+url = "https://github.com/flyx/OpenGLAda/releases/download/v0.9.0/openglada_images-0.9.0.tgz"
+

--- a/index/op/openglada_text/openglada_text-0.9.0.toml
+++ b/index/op/openglada_text/openglada_text-0.9.0.toml
@@ -7,6 +7,7 @@ licenses = "MIT"
 maintainers = ["Felix Krause <contact@flyx.org>"]
 maintainers-logins = ["flyx"]
 project-files = ["opengl-text.gpr"]
+tags = ["opengl", "rendering", "fonts"]
 
 [[depends-on]]
 openglada = "~0.9.0"

--- a/index/op/openglada_text/openglada_text-0.9.0.toml
+++ b/index/op/openglada_text/openglada_text-0.9.0.toml
@@ -1,0 +1,21 @@
+name = "openglada_text"
+description = "Text rendering library for OpenGLAda"
+version = "0.9.0"
+website = "http://flyx.github.io/OpenGLAda/"
+authors = ["Felix Krause"]
+licenses = "MIT"
+maintainers = ["Felix Krause <contact@flyx.org>"]
+maintainers-logins = ["flyx"]
+project-files = ["opengl-text.gpr"]
+
+[[depends-on]]
+openglada = "~0.9.0"
+freetypeada = "~0.1.0"
+
+
+[origin]
+hashes = [
+"sha512:9ca805328a927155a1bc7672115d95a757e7ad2529e8a71d7ac6c148e481b624e724c82eb810d6faa403d5a730042723dae7566a207863f53e290a5066b6f438",
+]
+url = "https://github.com/flyx/OpenGLAda/releases/download/v0.9.0/openglada_text-0.9.0.tgz"
+


### PR DESCRIPTION
Split into four crates due to optional dependencies.