### PR TITLE
Fix utilada Windows build

### DIFF
--- a/index/ut/utilada/utilada-2.0.0.toml
+++ b/index/ut/utilada/utilada-2.0.0.toml
@@ -26,10 +26,10 @@ UTIL_OS = "linux64"
 [gpr-set-externals."case(os)".macos]
 UTIL_OS = "macos64"
 [gpr-set-externals."case(os)".windows."case(word-size)".bits-32]
-UTIL_OS = "windows32"
+UTIL_OS = "win32"
 
 [gpr-set-externals."case(os)".windows."case(word-size)".bits-64]
-UTIL_OS = "windows64"
+UTIL_OS = "win64"
 
 [origin]
 url = "https://github.com/stcarrez/ada-util/archive/2.0.0.tar.gz"

--- a/index/ut/utilada/utilada-2.1.0.toml
+++ b/index/ut/utilada/utilada-2.1.0.toml
@@ -26,10 +26,10 @@ UTIL_OS = "linux64"
 [gpr-set-externals."case(os)".macos]
 UTIL_OS = "macos64"
 [gpr-set-externals."case(os)".windows."case(word-size)".bits-32]
-UTIL_OS = "windows32"
+UTIL_OS = "win32"
 
 [gpr-set-externals."case(os)".windows."case(word-size)".bits-64]
-UTIL_OS = "windows64"
+UTIL_OS = "win64"
 
 [origin]
 url = "https://github.com/stcarrez/ada-util/archive/2.1.0.tar.gz"


### PR DESCRIPTION
windows32/64 are not legal for UTIL_OS. win32/win64 are.
This patch is not testet,