### PR TITLE
are 1.1.0: Advanced Resource Embedder

### DIFF
--- a/index/ar/are/are-1.1.0.toml
+++ b/index/ar/are/are-1.1.0.toml
@@ -54,12 +54,28 @@ xmlada = "~21.0.0"
 [gpr-externals]
 BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
 ARE_SWITCH = ["NO_CALLBACK", "HAS_CALLBACK"]
+UTIL_OS = ["win32", "win64", "linux32", "linux64", "macos64", "netbsd32", "netbsd64", "freebsd32", "freebsd64"]
 
 [gpr-set-externals]
 BUILD = "distrib"
 ARE_SWITCH = "NO_CALLBACK"
 
+[gpr-set-externals."case(os)".linux."case(word-size)".bits-32]
+UTIL_OS = "linux32"
+
+[gpr-set-externals."case(os)".linux."case(word-size)".bits-64]
+UTIL_OS = "linux64"
+
+[gpr-set-externals."case(os)".macos]
+UTIL_OS = "macos64"
+
+[gpr-set-externals."case(os)".windows."case(word-size)".bits-32]
+UTIL_OS = "win32"
+
+[gpr-set-externals."case(os)".windows."case(word-size)".bits-64]
+UTIL_OS = "win64"
+
 [origin]
-commit = "f957e3acc7159d9b0653a6fa25ca957e93036c6d"
+commit = "cf491d2c73c90daace4e39dbc221a4b4990a349f"
 url = "git+https://github.com/stcarrez/resource-embedder.git"
 

--- a/index/ar/are/are-1.1.0.toml
+++ b/index/ar/are/are-1.1.0.toml
@@ -42,6 +42,9 @@ end Config;
 
 """
 
+[[depends-on]]
+xmlada = "~21.0.0"
+
 [gpr-externals]
 BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
 ARE_SWITCH = ["NO_CALLBACK", "HAS_CALLBACK"]
@@ -51,6 +54,6 @@ BUILD = "distrib"
 ARE_SWITCH = "NO_CALLBACK"
 
 [origin]
-commit = "ccf920512964fb1c91fe7b6935d3d0c3f2035080"
+commit = "9937cc29c7aa23626ac66b0c2653d6f5cbacca6a"
 url = "git+https://github.com/stcarrez/resource-embedder.git"
 

--- a/index/ar/are/are-1.1.0.toml
+++ b/index/ar/are/are-1.1.0.toml
@@ -1,0 +1,56 @@
+description = "Advanced Resource Embedder"
+name = "are"
+version = "1.1.0"
+authors = ["Stephane.Carrez@gmail.com"]
+licenses = "Apache-2.0"
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+project-files = ["are.gpr"]
+tags = ["resource", "embedder", "generator"]
+website = "https://gitlab.com/stcarrez/resource-embedder"
+long-description = """
+
+[![Build Status](https://img.shields.io/jenkins/s/https/jenkins.vacs.fr/Bionic-Resource-Embedder.svg)](http://jenkins.vacs.fr/job/Bionic-Resource-Embedder/)
+[![Test Status](https://img.shields.io/jenkins/t/https/jenkins.vacs.fr/Bionic-Resource-Embedder.svg)](http://jenkins.vacs.fr/job/Bionic-Resource-Embedder/)
+[![codecov](https://codecov.io/gh/stcarrez/resource-embedder/branch/master/graph/badge.svg)](https://codecov.io/gh/stcarrez/resource-embedder)
+[![Documentation Status](https://readthedocs.org/projects/resource-embedder/badge/?version=latest)](https://resource-embedder.readthedocs.io/en/latest/?badge=latest)
+
+The resource embedder allows to embed files in binaries by producing C, Ada or Go source
+files that contain the original files.
+
+To generate a `config.ads` and `config.adb` Ada package with the resources, you may use:
+
+```
+are --lang=Ada -o src --resource=config --name-access --fileset='**/*.conf' config
+```
+
+Complex resource integrations are best described with and XML and are generated with:
+
+```
+are --lang=Ada -o src --rule=package.xml --name-access .
+```
+
+For Ada, it generates the following package declaration with the `Get_Content` function
+that gives access to the files.  The Ada body contains the content of each embedded file.
+
+```Ada
+package Config is
+  function Get_Content (Name : in String)
+    return access constant String;
+end Config;
+```
+
+"""
+
+[gpr-externals]
+BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
+ARE_SWITCH = ["NO_CALLBACK", "HAS_CALLBACK"]
+
+[gpr-set-externals]
+BUILD = "distrib"
+ARE_SWITCH = "NO_CALLBACK"
+
+[origin]
+commit = "ccf920512964fb1c91fe7b6935d3d0c3f2035080"
+url = "git+https://github.com/stcarrez/resource-embedder.git"
+

--- a/index/ar/are/are-1.1.0.toml
+++ b/index/ar/are/are-1.1.0.toml
@@ -42,6 +42,12 @@ end Config;
 
 """
 
+[available.'case(os)']
+linux = true
+windows = true
+macos = false
+'...' = false
+
 [[depends-on]]
 xmlada = "~21.0.0"
 
@@ -54,6 +60,6 @@ BUILD = "distrib"
 ARE_SWITCH = "NO_CALLBACK"
 
 [origin]
-commit = "9937cc29c7aa23626ac66b0c2653d6f5cbacca6a"
+commit = "f957e3acc7159d9b0653a6fa25ca957e93036c6d"
 url = "git+https://github.com/stcarrez/resource-embedder.git"
 


### PR DESCRIPTION
This pull request adds **are** as a crate to build and have access to the Advance Resource Embedder.

It allows to generate Ada, C and Go code in order to integrate easily files in an Ada program.

The new release 1.1.0 introduces:

- Add support to emit Ada String types for embedded content
- Add support to represent content as an array of lines
- New example to show the new 'lines' resource format

Fabien suggested to provide an Alire package for my project, here it is :-)

Note that this is a tool, not a library.