### PR TITLE
Add Felix package, update Blake2s

### DIFF
--- a/index/bl/blake2s/blake2s-0.1.1.toml
+++ b/index/bl/blake2s/blake2s-0.1.1.toml
@@ -1,0 +1,15 @@
+name = "blake2s"
+description = "SPARK83 implementation of the BLAKE2s hash function"
+version = "0.1.1"
+
+authors = ["Lev Kujawski"]
+maintainers = ["Lev Kujawski <int21h@mailbox.org>"]
+maintainers-logins = ["lkujaw"]
+licenses = "MIT-0"
+website = "https://github.com/lkujaw/blake2s"
+tags = ["ada1987", "spark", "hash", "blake2", "blake2s"]
+
+[origin]
+commit = "dfd349378dca21ca354a6f6858ab9d623c7a949e"
+url = "git+https://github.com/lkujaw/blake2s.git"
+

--- a/index/fe/felix/felix-0.1.0.toml
+++ b/index/fe/felix/felix-0.1.0.toml
@@ -1,0 +1,20 @@
+name = "felix"
+description = "X/Open Native Language System (NLS) for Ada"
+version = "0.1.0"
+
+authors = ["Lev Kujawski"]
+maintainers = ["Lev Kujawski <int21h@mailbox.org>"]
+maintainers-logins = ["lkujaw"]
+licenses = "MIT-0"
+website = "https://github.com/lkujaw/felix"
+tags = ["ada1995", "i18n", "nls",
+        "localization", "localisation", "l10n"]
+
+# The underlying interface is dependent upon the Unix C library.
+[available.'case(os)']
+'windows' = false
+
+[origin]
+commit = "6b030f1b7fa20684ff06a146f3b48e43bd8bdfd3"
+url = "git+https://github.com/lkujaw/felix.git"
+


### PR DESCRIPTION
Hi,

I have two commits here, one is to update the blake2s package per the suggestion of @Fabien-Chouteau (thank you!) to enable optimizations by default. Indeed, doing so nearly triples throughput on my laptop, whereas a copy of b2ssum built against the Alire library was trailing sha256sum before. I think a change in the documentation might be helpful, as it currently mentions that the GPR file is standardized and I was reluctant to tinker with it too much since I did not know if Alire set the external variables as part of the build process.

Secondly, I have put together a small native language support package for Unix systems. It uses standard C I/O routines to the greatest possible extent, so that, e.g., the user's LC_NUMERIC setting is honored. There is a GNU gettext interface bundled with GtkAda, but that's a rather heavy dependency and, to the best of my knowledge, it is not possible for the translator to specify the position and format of arguments like numbers.

Thanks, Lev