### PR TITLE
Disable toolchain installation in setup-alire@latest-devel

### DIFF
--- a/.github/workflows/build-crate.yml
+++ b/.github/workflows/build-crate.yml
@@ -78,6 +78,8 @@ jobs:
     - name: Set up devel `alr`
       if: contains(github.base_ref, 'devel-')
       uses: alire-project/setup-alire@latest-devel
+      with:
+        toolchain: --disable-assistant # We want to use the external ones
 
     - name: Test crate (Linux)
       if: matrix.os == 'ubuntu-latest' # docker testing only for linuxes


### PR DESCRIPTION
As we want to use the ones set up externally. At some point, for non-docker, non-distro tests, we should rely on the toolchain installed by the action instead.