### PR TITLE
Bugfix for CI build script related to multiple simultaneous crate submission

### DIFF
--- a/scripts/gh-build-crate.sh
+++ b/scripts/gh-build-crate.sh
@@ -145,7 +145,7 @@ for file in $CHANGES; do
       echo FETCHED BINARY crate OK
    else
       echo LISTING EXECUTABLES of crate $milestone
-      cd ${crate}_*
+      cd ${crate}_${version}_*
       alr run -d --list
       cd ..
    fi


### PR DESCRIPTION
When several releases for the same crate were modified simultaneously, the step to list executables would fail.