### PR TITLE
lkujaw: Update blake2s (0.1.1 -> 0.1.3), add b2ssum hash utility

### DIFF
--- a/index/b2/b2ssum/b2ssum-0.1.3.toml
+++ b/index/b2/b2ssum/b2ssum-0.1.3.toml
@@ -1,0 +1,19 @@
+name = "b2ssum"
+description = "BLAKE2s file hash utility"
+version = "0.1.3"
+
+authors = ["Lev Kujawski"]
+maintainers = ["Lev Kujawski <int21h@mailbox.org>"]
+maintainers-logins = ["lkujaw"]
+licenses = "MIT-0"
+website = "https://github.com/lkujaw/blake2s"
+tags = ["ada1995", "hash", "blake2", "blake2s"]
+project-files = ["b2ssum.gpr"]
+executables = ["b2ssum"]
+
+[[depends-on]]
+blake2s = "~0.1.3"
+
+[origin]
+commit = "63b5d12efb5f96afb8148dd3eb7248ac1449f68d"
+url = "git+https://github.com/lkujaw/blake2s.git"

--- a/index/bl/blake2s/blake2s-0.1.3.toml
+++ b/index/bl/blake2s/blake2s-0.1.3.toml
@@ -1,0 +1,14 @@
+name = "blake2s"
+description = "SPARK83 implementation of the BLAKE2s hash function"
+version = "0.1.3"
+
+authors = ["Lev Kujawski"]
+maintainers = ["Lev Kujawski <int21h@mailbox.org>"]
+maintainers-logins = ["lkujaw"]
+licenses = "MIT-0"
+website = "https://github.com/lkujaw/blake2s"
+tags = ["ada1987", "spark", "hash", "blake2", "blake2s"]
+
+[origin]
+commit = "63b5d12efb5f96afb8148dd3eb7248ac1449f68d"
+url = "git+https://github.com/lkujaw/blake2s.git"


### PR DESCRIPTION
Hi,

Congratulations on version 1.1! I've wanted to include the b2ssum utility (based on the blake2s library) in Alire for a while now, so I'm hoping this hand-edited TOML passes muster.

Kind regards, Lev

EDIT: It seems that one of the CI systems is failing with what appears to be an unrelated issue?
`stderr: Cannot locate gprbuild, please check that you have a GNAT and GPRbuild installation in your environment.`