### PR TITLE
avltrees 0.1.0

### DIFF
--- a/index/av/avltrees/avltrees-0.1.0.toml
+++ b/index/av/avltrees/avltrees-0.1.0.toml
@@ -1,0 +1,15 @@
+name = "avltrees"
+description = "Threaded AVL trees library for Ada"
+version = "0.1.0"
+
+authors = ["Lev Kujawski"]
+maintainers = ["Lev Kujawski <int21h@mailbox.org>"]
+maintainers-logins = ["lkujaw"]
+licenses = "LGPL-3.0-or-later"
+website = "https://github.com/lkujaw/avltrees"
+tags = ["ada1987", "data-structures"]
+
+[origin]
+commit = "81b318c6c9ba2ee500d0acc92a122bb8fe58f5ff"
+url = "git+https://github.com/lkujaw/avltrees.git"
+


### PR DESCRIPTION
Hello,

This package provides an implementation of threaded AVL trees for Ada 1987 and later, as needed by the next release of Felix. Thank you for the time and effort involved in maintaining the index.

Kind regards, Lev