### PR TITLE
Show environment before building

### DIFF
--- a/scripts/gh-build-crate.sh
+++ b/scripts/gh-build-crate.sh
@@ -135,12 +135,11 @@ for file in $CHANGES; do
    echo DEPLOYING CRATE $milestone
    if $is_binary; then
       echo SKIPPING BUILD for BINARY crate, FETCHING only
-      build_flag=""
-   else
-      build_flag="--build"
+   elif $is_system; then
+      echo SKIPPING BUILD for SYSTEM crate, FETCHING only
    fi
 
-   alr get -d $build_flag -n $milestone
+   alr get -d -n $milestone
 
    if $is_system; then
       echo DETECTING INSTALLED PACKAGE via crate $milestone
@@ -148,9 +147,12 @@ for file in $CHANGES; do
    elif $is_binary; then
       echo FETCHED BINARY crate OK
    else
+      echo FETCHED SOURCE crate OK
       cd ${crate}_${version_noextras}_*
       echo BUILD ENVIRONMENT
       alr printenv
+      echo BUILDING CRATE
+      alr build -d -n 
       echo LISTING EXECUTABLES of crate $milestone
       alr run -d --list
       cd ..

--- a/scripts/gh-build-crate.sh
+++ b/scripts/gh-build-crate.sh
@@ -139,11 +139,11 @@ for file in $CHANGES; do
       echo SKIPPING BUILD for SYSTEM crate, FETCHING only
    fi
 
-   alr get -d -n $milestone
+   alr -d -n get $milestone
 
    if $is_system; then
       echo DETECTING INSTALLED PACKAGE via crate $milestone
-      alr show -d --external-detect $milestone
+      alr -d show --external-detect $milestone
    elif $is_binary; then
       echo FETCHED BINARY crate OK
    else
@@ -152,9 +152,9 @@ for file in $CHANGES; do
       echo BUILD ENVIRONMENT
       alr printenv
       echo BUILDING CRATE
-      alr build -d -n 
+      alr -d -n build 
       echo LISTING EXECUTABLES of crate $milestone
-      alr run -d --list
+      alr -d run --list
       cd ..
    fi
 


### PR DESCRIPTION
This way we can check the environment even if the build fails afterwards.

Checked with a crate at https://github.com/mosteo/alire-index/pull/36