### PR TITLE
Add Matreshka 21.0 release

### DIFF
--- a/index/ma/matreshka_amf/matreshka_amf-21.0.0.toml
+++ b/index/ma/matreshka_amf/matreshka_amf-21.0.0.toml
@@ -1,0 +1,22 @@
+description = "Implementation of OMG's Meta Object Facility (MOF)"
+name = "matreshka_amf"
+version = "21.0.0"
+website = "https://forge.ada-ru.org/matreshka"
+authors = ["Vadim Godunko"]
+licenses = "BSD-3-Clause"
+maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]
+maintainers-logins = ["godunko", "reznikmm"]
+project-files = ["build_matreshka_amf.gpr"]
+tags = ["uml", "meta", "mof"]
+
+[available.'case(os)']
+windows = false
+'...'   = true
+
+[[depends-on]]
+matreshka_league = "21.0.0"
+matreshka_xml = "21.0.0"
+
+[origin]
+url = "git+https://github.com/reznikmm/matreshka-alire"
+commit = "abff6b28bdb8e19de9f9c27c6dd3107d981adb22"

--- a/index/ma/matreshka_amf_dd/matreshka_amf_dd-21.0.0.toml
+++ b/index/ma/matreshka_amf_dd/matreshka_amf_dd-21.0.0.toml
@@ -1,0 +1,18 @@
+description = "Diagram Definition (DD) specification support for AMF"
+name = "matreshka_amf_dd"
+version = "21.0.0"
+website = "https://forge.ada-ru.org/matreshka"
+authors = ["Vadim Godunko"]
+licenses = "BSD-3-Clause"
+maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]
+maintainers-logins = ["godunko", "reznikmm"]
+project-files = ["build_matreshka_amf_dd.gpr"]
+tags = ["uml", "meta", "diagram"]
+
+[[depends-on]]
+matreshka_amf = "21.0.0"
+matreshka_league = "21.0.0"
+
+[origin]
+url = "git+https://github.com/reznikmm/matreshka-alire"
+commit = "d9f26bf491a2bfd76c4396fd8f49459bc230423a"

--- a/index/ma/matreshka_amf_mofext/matreshka_amf_mofext-21.0.0.toml
+++ b/index/ma/matreshka_amf_mofext/matreshka_amf_mofext-21.0.0.toml
@@ -1,0 +1,18 @@
+description = "The UML mofext for AMF"
+name = "matreshka_amf_mofext"
+version = "21.0.0"
+website = "https://forge.ada-ru.org/matreshka"
+authors = ["Vadim Godunko"]
+licenses = "BSD-3-Clause"
+maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]
+maintainers-logins = ["godunko", "reznikmm"]
+project-files = ["build_matreshka_amf_mofext.gpr"]
+tags = ["uml", "meta", "diagram"]
+
+[[depends-on]]
+matreshka_amf_uml = "21.0.0"
+matreshka_league = "21.0.0"
+
+[origin]
+url = "git+https://github.com/reznikmm/matreshka-alire"
+commit = "1ae53d45dcee2172c03ed7856a6f194d6deb4f27"

--- a/index/ma/matreshka_amf_ocl/matreshka_amf_ocl-21.0.0.toml
+++ b/index/ma/matreshka_amf_ocl/matreshka_amf_ocl-21.0.0.toml
@@ -1,0 +1,18 @@
+description = "The UML OCL for AMF"
+name = "matreshka_amf_ocl"
+version = "21.0.0"
+website = "https://forge.ada-ru.org/matreshka"
+authors = ["Vadim Godunko"]
+licenses = "BSD-3-Clause"
+maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]
+maintainers-logins = ["godunko", "reznikmm"]
+project-files = ["build_matreshka_amf_ocl.gpr"]
+tags = ["uml", "meta", "diagram", "ocl"]
+
+[[depends-on]]
+matreshka_amf_uml = "21.0.0"
+matreshka_league = "21.0.0"
+
+[origin]
+url = "git+https://github.com/reznikmm/matreshka-alire"
+commit = "aedf6e4d7d264c66156294e3cb10938ed17e14c8"

--- a/index/ma/matreshka_amf_uml/matreshka_amf_uml-21.0.0.toml
+++ b/index/ma/matreshka_amf_uml/matreshka_amf_uml-21.0.0.toml
@@ -1,0 +1,18 @@
+description = "Unified Modeling Language support for AMF"
+name = "matreshka_amf_uml"
+version = "21.0.0"
+website = "https://forge.ada-ru.org/matreshka"
+authors = ["Vadim Godunko"]
+licenses = "BSD-3-Clause"
+maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]
+maintainers-logins = ["godunko", "reznikmm"]
+project-files = ["build_matreshka_amf_uml.gpr"]
+tags = ["uml", "meta", "diagram"]
+
+[[depends-on]]
+matreshka_amf_dd = "21.0.0"
+matreshka_league = "21.0.0"
+
+[origin]
+url = "git+https://github.com/reznikmm/matreshka-alire"
+commit = "2d78ddd950f19e9806ff6e81b14b12b35385e7fe"

--- a/index/ma/matreshka_amf_utp/matreshka_amf_utp-21.0.0.toml
+++ b/index/ma/matreshka_amf_utp/matreshka_amf_utp-21.0.0.toml
@@ -1,0 +1,18 @@
+description = "The UML Testing Profile for AMF"
+name = "matreshka_amf_utp"
+version = "21.0.0"
+website = "https://forge.ada-ru.org/matreshka"
+authors = ["Vadim Godunko"]
+licenses = "BSD-3-Clause"
+maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]
+maintainers-logins = ["godunko", "reznikmm"]
+project-files = ["build_matreshka_amf_utp.gpr"]
+tags = ["uml", "meta", "diagram", "testing"]
+
+[[depends-on]]
+matreshka_amf_uml = "21.0.0"
+matreshka_league = "21.0.0"
+
+[origin]
+url = "git+https://github.com/reznikmm/matreshka-alire"
+commit = "ecbb733e1e66e6d9a51501d148a1733e47da2fef"

--- a/index/ma/matreshka_fastcgi/matreshka_fastcgi-21.0.0.toml
+++ b/index/ma/matreshka_fastcgi/matreshka_fastcgi-21.0.0.toml
@@ -1,0 +1,17 @@
+description = "FastCGI implementation (demo)"
+name = "matreshka_fastcgi"
+version = "21.0.0"
+website = "https://forge.ada-ru.org/matreshka"
+authors = ["Vadim Godunko"]
+licenses = "BSD-3-Clause"
+maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]
+maintainers-logins = ["godunko", "reznikmm"]
+project-files = ["build_matreshka_fastcgi.gpr"]
+tags = ["web", "cgi", "http"]
+
+[[depends-on]]
+matreshka_league = "21.0.0"
+
+[origin]
+url = "git+https://github.com/reznikmm/matreshka-alire"
+commit = "20fa445356c12b414c5500fddf59d55bf9c08c97"

--- a/index/ma/matreshka_league/matreshka_league-21.0.0.toml
+++ b/index/ma/matreshka_league/matreshka_league-21.0.0.toml
@@ -1,0 +1,26 @@
+description = "League - universal string library. Part of Matreshka framework"
+name = "matreshka_league"
+version = "21.0.0"
+website = "https://forge.ada-ru.org/matreshka"
+authors = ["Vadim Godunko"]
+licenses = "BSD-3-Clause"
+maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]
+maintainers-logins = ["godunko", "reznikmm"]
+project-files = ["gnat/matreshka_league.gpr"]
+tags = ["unicode", "xml", "sax", "json", "encoding", "regexp", "time"]
+
+[[actions]]
+type = "post-fetch"
+command = ["make", "reconfig"]
+
+[[depends-on]]
+make = "any"
+
+[depends-on.'case(os)'.macos]
+gnat = "<2000"
+# GNAT CE 2020 miss TLS support, alire GCC 11 works fine
+
+[origin]
+url = "http://forge.ada-ru.org/matreshka/downloads/matreshka-21.0.tar.gz"
+archive-name = "matreshka-21.0.tar.gz"
+hashes = ["sha512:0c8f4d478d64e761967b3bcb7aae56fe08c4dd254acfe17a704cf21d2ba9f4b8faed470268c8c6dfa2b6e0dcab64e5fdaae04361657b8d5fa85dd35e6a76e9b2"]

--- a/index/ma/matreshka_servlet/matreshka_servlet-21.0.0.toml
+++ b/index/ma/matreshka_servlet/matreshka_servlet-21.0.0.toml
@@ -1,0 +1,17 @@
+description = "Servlet API"
+name = "matreshka_servlet"
+version = "21.0.0"
+website = "https://forge.ada-ru.org/matreshka"
+authors = ["Vadim Godunko"]
+licenses = "BSD-3-Clause"
+maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]
+maintainers-logins = ["godunko", "reznikmm"]
+project-files = ["build_matreshka_servlet.gpr"]
+tags = ["web", "servlet", "http"]
+
+[[depends-on]]
+matreshka_league = "21.0.0"
+
+[origin]
+url = "git+https://github.com/reznikmm/matreshka-alire"
+commit = "e6463c55cfc662b3f738175e855fb9bf6cdfd3b8"

--- a/index/ma/matreshka_soap/matreshka_soap-21.0.0.toml
+++ b/index/ma/matreshka_soap/matreshka_soap-21.0.0.toml
@@ -1,0 +1,18 @@
+description = "Framework for work with SOAP 1.2"
+name = "matreshka_soap"
+version = "21.0.0"
+website = "https://forge.ada-ru.org/matreshka"
+authors = ["Vadim Godunko"]
+licenses = "BSD-3-Clause"
+maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]
+maintainers-logins = ["godunko", "reznikmm"]
+project-files = ["build_matreshka_soap.gpr"]
+tags = ["soap", "rpc", "protocol", "web"]
+
+[[depends-on]]
+matreshka_league = "21.0.0"
+matreshka_xml = "21.0.0"
+
+[origin]
+url = "git+https://github.com/reznikmm/matreshka-alire"
+commit = "f0e001315430e87814c080acade5b26edb747b1e"

--- a/index/ma/matreshka_soap_wsse/matreshka_soap_wsse-21.0.0.toml
+++ b/index/ma/matreshka_soap_wsse/matreshka_soap_wsse-21.0.0.toml
@@ -1,0 +1,18 @@
+description = "WS-Security 1.1 implementation for SOAP 1.2"
+name = "matreshka_soap_wsse"
+version = "21.0.0"
+website = "https://forge.ada-ru.org/matreshka"
+authors = ["Vadim Godunko"]
+licenses = "BSD-3-Clause"
+maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]
+maintainers-logins = ["godunko", "reznikmm"]
+project-files = ["build_matreshka_soap_wsse.gpr"]
+tags = ["soap", "wsse", "web"]
+
+[[depends-on]]
+matreshka_league = "21.0.0"
+matreshka_soap = "21.0.0"
+
+[origin]
+url = "git+https://github.com/reznikmm/matreshka-alire"
+commit = "2a4cb0c0f17201bc8e116706a9db4adc78f7d644"

--- a/index/ma/matreshka_spikedog_api/matreshka_spikedog_api-21.0.0.toml
+++ b/index/ma/matreshka_spikedog_api/matreshka_spikedog_api-21.0.0.toml
@@ -1,0 +1,18 @@
+description = "Web-application server. API library"
+name = "matreshka_spikedog_api"
+version = "21.0.0"
+website = "https://forge.ada-ru.org/matreshka"
+authors = ["Vadim Godunko"]
+licenses = "BSD-3-Clause"
+maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]
+maintainers-logins = ["godunko", "reznikmm"]
+project-files = ["build_matreshka_spikedog_api.gpr"]
+tags = ["web", "servlet"]
+
+[[depends-on]]
+matreshka_league = "21.0.0"
+matreshka_servlet = "21.0.0"
+
+[origin]
+url = "git+https://github.com/reznikmm/matreshka-alire"
+commit = "2b70f85edf6c8ebc980d54c9b0e918ebaa0a4535"

--- a/index/ma/matreshka_spikedog_awsd/matreshka_spikedog_awsd-21.0.0.toml
+++ b/index/ma/matreshka_spikedog_awsd/matreshka_spikedog_awsd-21.0.0.toml
@@ -1,0 +1,23 @@
+description = "Web-application server. API library"
+name = "matreshka_spikedog_awsd"
+version = "21.0.0"
+website = "https://forge.ada-ru.org/matreshka"
+authors = ["Vadim Godunko"]
+executables = ["spikedog_awsd"]
+licenses = "BSD-3-Clause"
+maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]
+maintainers-logins = ["godunko", "reznikmm"]
+project-files = ["build_matreshka_spikedog_awsd.gpr"]
+tags = ["web", "servlet"]
+
+[[depends-on]]
+aws = "any"
+matreshka_league = "21.0.0"
+matreshka_spikedog_core = "21.0.0"
+
+[gpr-set-externals]
+LIBRARY_TYPE="relocatable"
+
+[origin]
+url = "git+https://github.com/reznikmm/matreshka-alire"
+commit = "1478b224545c3fa67dc5a8899d3c535d61dc41e6"

--- a/index/ma/matreshka_spikedog_core/matreshka_spikedog_core-21.0.0.toml
+++ b/index/ma/matreshka_spikedog_core/matreshka_spikedog_core-21.0.0.toml
@@ -1,0 +1,18 @@
+description = "Web-application server. Implementation library"
+name = "matreshka_spikedog_core"
+version = "21.0.0"
+website = "https://forge.ada-ru.org/matreshka"
+authors = ["Vadim Godunko"]
+licenses = "BSD-3-Clause"
+maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]
+maintainers-logins = ["godunko", "reznikmm"]
+project-files = ["build_matreshka_spikedog_core.gpr"]
+tags = ["web", "servlet"]
+
+[[depends-on]]
+matreshka_league = "21.0.0"
+matreshka_spikedog_api = "21.0.0"
+
+[origin]
+url = "git+https://github.com/reznikmm/matreshka-alire"
+commit = "8932a8f4aec45d6818176162c5632f7df81ae688"

--- a/index/ma/matreshka_sql/matreshka_sql-21.0.0.toml
+++ b/index/ma/matreshka_sql/matreshka_sql-21.0.0.toml
@@ -1,0 +1,17 @@
+description = "Common SQL Database API"
+name = "matreshka_sql"
+version = "21.0.0"
+website = "https://forge.ada-ru.org/matreshka"
+authors = ["Vadim Godunko"]
+licenses = "BSD-3-Clause"
+maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]
+maintainers-logins = ["godunko", "reznikmm"]
+project-files = ["build_matreshka_sql.gpr"]
+tags = ["sql", "database", "db"]
+
+[[depends-on]]
+matreshka_league = "21.0.0"
+
+[origin]
+url = "git+https://github.com/reznikmm/matreshka-alire"
+commit = "64f17b82f6b542fbe1790c7c3f207721969f939b"

--- a/index/ma/matreshka_sql_firebird/matreshka_sql_firebird-21.0.0.toml
+++ b/index/ma/matreshka_sql_firebird/matreshka_sql_firebird-21.0.0.toml
@@ -1,0 +1,19 @@
+description = "Firebird SQL binding for Ada"
+name = "matreshka_sql_firebird"
+version = "21.0.0"
+website = "https://forge.ada-ru.org/matreshka"
+authors = ["Vadim Godunko"]
+licenses = "BSD-3-Clause"
+maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]
+maintainers-logins = ["godunko", "reznikmm"]
+project-files = ["build_matreshka_sql_firebird.gpr"]
+tags = ["sql", "database", "db", "firebird"]
+
+[[depends-on]]
+libfbclient = "any"
+matreshka_league = "21.0.0"
+matreshka_sql = "21.0.0"
+
+[origin]
+url = "git+https://github.com/reznikmm/matreshka-alire"
+commit = "3f0d1ed6f8ca07fbe19bcb05ec8018a24d36c815"

--- a/index/ma/matreshka_sql_mysql/matreshka_sql_mysql-21.0.0.toml
+++ b/index/ma/matreshka_sql_mysql/matreshka_sql_mysql-21.0.0.toml
@@ -1,0 +1,19 @@
+description = "MySQL binding for Ada"
+name = "matreshka_sql_mysql"
+version = "21.0.0"
+website = "https://forge.ada-ru.org/matreshka"
+authors = ["Vadim Godunko"]
+licenses = "BSD-3-Clause"
+maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]
+maintainers-logins = ["godunko", "reznikmm"]
+project-files = ["build_matreshka_sql_mysql.gpr"]
+tags = ["sql", "database", "db", "mysql", "mariadb"]
+
+[[depends-on]]
+libmysqlclient = "any"
+matreshka_league = "21.0.0"
+matreshka_sql = "21.0.0"
+
+[origin]
+url = "git+https://github.com/reznikmm/matreshka-alire"
+commit = "e880d413a557f324505cf8fdf2857c38a3007b37"

--- a/index/ma/matreshka_sql_oracle/matreshka_sql_oracle-21.0.0.toml
+++ b/index/ma/matreshka_sql_oracle/matreshka_sql_oracle-21.0.0.toml
@@ -1,0 +1,19 @@
+description = "Oracle DB binding for Ada"
+name = "matreshka_sql_oracle"
+version = "21.0.0"
+website = "https://forge.ada-ru.org/matreshka"
+authors = ["Vadim Godunko"]
+licenses = "BSD-3-Clause"
+maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]
+maintainers-logins = ["godunko", "reznikmm"]
+project-files = ["build_matreshka_sql_oracle.gpr"]
+tags = ["sql", "database", "db", "oracle"]
+
+[[depends-on]]
+libclntsh = "any"
+matreshka_league = "21.0.0"
+matreshka_sql = "21.0.0"
+
+[origin]
+url = "git+https://github.com/reznikmm/matreshka-alire"
+commit = "642d7f2873eb626a335fe5a5e424f604ccb66726"

--- a/index/ma/matreshka_sql_postgresql/matreshka_sql_postgresql-21.0.0.toml
+++ b/index/ma/matreshka_sql_postgresql/matreshka_sql_postgresql-21.0.0.toml
@@ -1,0 +1,23 @@
+description = "PostgreSQL binding for Ada"
+name = "matreshka_sql_postgresql"
+version = "21.0.0"
+website = "https://forge.ada-ru.org/matreshka"
+authors = ["Vadim Godunko"]
+licenses = "BSD-3-Clause"
+maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]
+maintainers-logins = ["godunko", "reznikmm"]
+project-files = ["build_matreshka_sql_postgresql.gpr"]
+tags = ["sql", "database", "db", "postgresql"]
+
+# Configure on msys2 fails to work with pg_config
+[available.'case(os)']
+windows = false
+'...'   = true
+
+[[depends-on]]
+libpq = "any"
+matreshka_league = "21.0.0"
+
+[origin]
+url = "git+https://github.com/reznikmm/matreshka-alire"
+commit = "8a4efceaaf37b1a2247ce8d07f44186e4c683afe"

--- a/index/ma/matreshka_sql_sqlite3/matreshka_sql_sqlite3-21.0.0.toml
+++ b/index/ma/matreshka_sql_sqlite3/matreshka_sql_sqlite3-21.0.0.toml
@@ -1,0 +1,18 @@
+description = "SQLite binding for Ada"
+name = "matreshka_sql_sqlite3"
+version = "21.0.0"
+website = "https://forge.ada-ru.org/matreshka"
+authors = ["Vadim Godunko"]
+licenses = "BSD-3-Clause"
+maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]
+maintainers-logins = ["godunko", "reznikmm"]
+project-files = ["build_matreshka_sql_sqlite3.gpr"]
+tags = ["sql", "database", "db", "sqlite"]
+
+[[depends-on]]
+libsqlite3 = "any"
+matreshka_league = "21.0.0"
+
+[origin]
+url = "git+https://github.com/reznikmm/matreshka-alire"
+commit = "0ae8347db103c231d60bc4b795461aa4e6c73696"

--- a/index/ma/matreshka_xml/matreshka_xml-21.0.0.toml
+++ b/index/ma/matreshka_xml/matreshka_xml-21.0.0.toml
@@ -1,0 +1,17 @@
+description = "Library to manipulate with XML streams and documents"
+name = "matreshka_xml"
+version = "21.0.0"
+website = "https://forge.ada-ru.org/matreshka"
+authors = ["Vadim Godunko"]
+licenses = "BSD-3-Clause"
+maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]
+maintainers-logins = ["godunko", "reznikmm"]
+project-files = ["build_matreshka_xml.gpr"]
+tags = ["xml", "dom", "catalog", "templates", "html5"]
+
+[[depends-on]]
+matreshka_league = "21.0.0"
+
+[origin]
+url = "git+https://github.com/reznikmm/matreshka-alire"
+commit = "fbca8dc8c20531b101403df03352f1dfb70791c6"


### PR DESCRIPTION
Replace project archives with github URL and commits. Disable GNAT CE compilers for MacOS, because they miss TLS support.