### PR TITLE
Fix matreshka 20.1 build.

### DIFF
--- a/index/ma/matreshka_league/matreshka_league-20.1.0.toml
+++ b/index/ma/matreshka_league/matreshka_league-20.1.0.toml
@@ -11,12 +11,22 @@ tags = ["unicode", "xml", "sax", "json", "encoding", "regexp", "time"]
 
 [[actions]]
 type = "post-fetch"
-command = ["make", "reconfig"]
+command = ["make", "--always-make", "reconfig"]
 
 [[depends-on]]
 make = "any"
 
+# GNAT 11 and GNAT CE 2021 complains:
+# violation of restriction "No_Elaboration_Code"
+
+[depends-on.'case(os)'.'macos']
+gnat = "<11"
+# GNAT CE 2020 miss TLS support, alire GCC 10 should work fine
+
+[depends-on.'case(os)'.'...']
+gnat = "<11|(>=2000 & <2021)"
+
 [origin]
 url = "http://forge.ada-ru.org/matreshka/downloads/matreshka-20.1.tar.gz"
-archive-name = "matreshka-18.1.tar.gz"
+archive-name = "matreshka-20.1.tar.gz"
 hashes = ["sha512:41ddb44a6073cb57c88e25024f6e2db94003e98263ef38feecb752021d6e9213c12303efc2557e1842100aa4f52d3b58323319dcc1394fe21d3514258c19e466"]

--- a/index/ma/matreshka_spikedog_awsd/matreshka_spikedog_awsd-20.1.0.toml
+++ b/index/ma/matreshka_spikedog_awsd/matreshka_spikedog_awsd-20.1.0.toml
@@ -15,7 +15,9 @@ aws = "any"
 matreshka_league = "20.1.0"
 matreshka_spikedog_core = "20.1.0"
 
+[gpr-set-externals]
+LIBRARY_TYPE="relocatable"
+
 [origin]
-# NOTE: Use the same dummy archive to build subproject as in 18.1
-url = "https://github.com/reznikmm/matreshka-alire/archive/matreshka_spikedog_awsd-18.1.tar.gz"
-hashes = ["sha512:b31fb7b6c8e936bec6d5ace196f264278a037f73b8c9c5fefa8d87ae0f563f666d64b9fe3f61f637c6c2bf56ee110d45c15d9a1b3a67e5f4d7bc8c932dd7f902"]
+url = "git+https://github.com/reznikmm/matreshka-alire"
+commit = "1478b224545c3fa67dc5a8899d3c535d61dc41e6"


### PR DESCRIPTION
Force `make reconfig` to ignore `config` directory created by `alr`.
Disable GNAT CE 2021 and GCC 11. Disable GNAT CE on Mac OS.
Fix building spikedog_awsd executable.