### PR TITLE
rp2040_hal, pico_bsp, pico_examples 1.1.0

### DIFF
--- a/index/pi/pico_bsp/pico_bsp-1.1.0.toml
+++ b/index/pi/pico_bsp/pico_bsp-1.1.0.toml
@@ -1,0 +1,22 @@
+name = "pico_bsp"
+description = "Board support package for Raspberry Pi Pico"
+version = "1.1.0"
+licenses = "BSD-3-Clause"
+
+authors = ["Jeremy Grosser"]
+maintainers = ["Jeremy Grosser <jeremy@synack.me>"]
+maintainers-logins = ["JeremyGrosser"]
+tags = ["embedded", "nostd", "raspberrypi", "pico", "rp2040", "bsp"]
+website = "https://pico-doc.synack.me/"
+
+[[depends-on]]
+hal = "~0.1"
+rp2040_hal = "^1"
+
+[configuration.values]
+rp2040_hal.Flash_Chip = "w25qxx"
+
+[origin]
+commit = "fdbf56f252e2304dbac5a4b9c924a751550ccd0d"
+url = "git+https://github.com/JeremyGrosser/pico_bsp.git"
+

--- a/index/pi/pico_examples/pico_examples-1.1.0.toml
+++ b/index/pi/pico_examples/pico_examples-1.1.0.toml
@@ -1,0 +1,34 @@
+name = "pico_examples"
+description = "Examples for Ada on the Raspberry Pi Pico"
+version = "1.1.0"
+
+authors = ["Jeremy Grosser"]
+maintainers = ["Jeremy Grosser <jeremy@synack.me>"]
+maintainers-logins = ["JeremyGrosser"]
+licenses = "BSD-3-Clause"
+tags = ["embedded", "nostd", "pico", "rp2040"]
+website = "https://pico-doc.synack.me/"
+auto-gpr-with=false
+project-files = [
+    "adc_continuous/adc_continuous.gpr",
+    "adc_hello/adc_hello.gpr",
+    "blink/blink.gpr",
+    "gpio_interrupts/gpio_interrupts.gpr",
+    "pimoroni_audio_pack/pimoroni_audio_pack.gpr",
+    "pimoroni_rgb_keypad/pimoroni_rgb_keypad.gpr",
+    "pimoroni_rgb_keypad_interrupt/pimoroni_rgb_keypad_interrupt.gpr",
+    "pio_blink/pio_blink.gpr",
+    "pwm/pwm.gpr",
+    "rtc/rtc.gpr",
+    "spi_loopback/spi_loopback.gpr",
+    "timer/timer.gpr",
+    "uart_echo/uart_echo.gpr",
+    "usb_echo/usb_echo.gpr"]
+
+[[depends-on]]
+pico_bsp = "^1"
+
+[origin]
+commit = "d2761e5dcb4e1566d3d192ca56f64d30252cf9d2"
+url = "git+https://github.com/JeremyGrosser/pico_examples.git"
+

--- a/index/rp/rp2040_hal/rp2040_hal-1.1.0.toml
+++ b/index/rp/rp2040_hal/rp2040_hal-1.1.0.toml
@@ -1,0 +1,28 @@
+name = "rp2040_hal"
+description = "Drivers and HAL for the RP2040 micro-controller family"
+version = "1.1.0"
+licenses = "BSD-3-Clause"
+
+authors = ["Jeremy Grosser"]
+maintainers = ["Jeremy Grosser <jeremy@synack.me>"]
+maintainers-logins = ["JeremyGrosser"]
+tags = ["embedded", "nostd", "rp2040", "raspberrypi", "drivers"]
+website = "https://pico-doc.synack.me/"
+
+[[depends-on]]
+cortex_m = "~0.3"
+hal = "~0.1"
+usb_embedded = "~0.2"
+gnat_arm_elf = "^11.2"
+
+[configuration.variables]
+Flash_Chip = {type = "Enum",  values = ["w25qxx", "generic_qspi", "generic_03"], default = "w25qxx"}
+Use_Startup = {type = "Boolean", default = true}
+
+[configuration.values]
+atomic.Backend = "armv6m"
+
+[origin]
+commit = "b10434ab542d69fc2dda065983fe3c3d9709a947"
+url = "git+https://github.com/JeremyGrosser/rp2040_hal.git"
+


### PR DESCRIPTION
pico_bsp and pico_examples have changed to only depend on `rp2040_hal = "~1"` so that we shouldn't need to bump them for every minor release.