### PR TITLE
Use sudo for system package updates

### DIFF
--- a/scripts/gh-build-crate.sh
+++ b/scripts/gh-build-crate.sh
@@ -96,7 +96,7 @@ for file in $CHANGES; do
    # Update system repositories whenever a detected system package is involved,
    # either as dependency or as the crate being tested.
    if grep -iq 'origin: system' <<< $solution; then
-      echo "UPDATING system repositories with sudo from user $USER ($UID)..."
+      echo "UPDATING system repositories with sudo from user ${USERNAME:-unset} ($UID:-unset)..."
       type apt-get 2>/dev/null && sudo apt-get update || true
       type pacman  2>/dev/null && sudo pacman -Syy    || true
    else

--- a/scripts/gh-build-crate.sh
+++ b/scripts/gh-build-crate.sh
@@ -96,7 +96,7 @@ for file in $CHANGES; do
    # Update system repositories whenever a detected system package is involved,
    # either as dependency or as the crate being tested.
    if grep -iq 'origin: system' <<< $solution; then
-      echo UPDATING system repositories...
+      echo "UPDATING system repositories as user $USER ($UID)..."
       type apt-get 2>/dev/null && apt-get update || true
       type pacman  2>/dev/null && pacman -Syy    || true
    else
@@ -152,7 +152,7 @@ for file in $CHANGES; do
       echo BUILD ENVIRONMENT
       alr printenv
       echo BUILDING CRATE
-      alr -d -n build 
+      alr -d -n build
       echo LISTING EXECUTABLES of crate $milestone
       alr -d run --list
       cd ..

--- a/scripts/gh-build-crate.sh
+++ b/scripts/gh-build-crate.sh
@@ -96,9 +96,9 @@ for file in $CHANGES; do
    # Update system repositories whenever a detected system package is involved,
    # either as dependency or as the crate being tested.
    if grep -iq 'origin: system' <<< $solution; then
-      echo "UPDATING system repositories as user $USER ($UID)..."
-      type apt-get 2>/dev/null && apt-get update || true
-      type pacman  2>/dev/null && pacman -Syy    || true
+      echo "UPDATING system repositories with sudo from user $USER ($UID)..."
+      type apt-get 2>/dev/null && sudo apt-get update || true
+      type pacman  2>/dev/null && sudo pacman -Syy    || true
    else
       echo No need to update system repositories
    fi


### PR DESCRIPTION
According to https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#administrative-privileges-of-github-hosted-runners and my tests the runner indeed does not run as root so `sudo` is needed.