### PR TITLE
rp2040_hal, pico_bsp, pico_examples 1.3.0

### DIFF
--- a/index/pi/pico_bsp/pico_bsp-1.3.0.toml
+++ b/index/pi/pico_bsp/pico_bsp-1.3.0.toml
@@ -1,0 +1,22 @@
+name = "pico_bsp"
+description = "Board support package for Raspberry Pi Pico"
+version = "1.3.0"
+licenses = "BSD-3-Clause"
+
+authors = ["Jeremy Grosser"]
+maintainers = ["Jeremy Grosser <jeremy@synack.me>"]
+maintainers-logins = ["JeremyGrosser"]
+tags = ["embedded", "nostd", "raspberrypi", "pico", "rp2040", "bsp"]
+website = "https://pico-doc.synack.me/"
+
+[[depends-on]]
+hal = "~0.1"
+rp2040_hal = "^1.3"
+
+[configuration.values]
+rp2040_hal.Flash_Chip = "w25qxx"
+
+[origin]
+commit = "4ff67b6d89e6346894388bdf69bbb069569a3b3d"
+url = "git+https://github.com/JeremyGrosser/pico_bsp.git"
+

--- a/index/pi/pico_examples/pico_examples-1.3.0.toml
+++ b/index/pi/pico_examples/pico_examples-1.3.0.toml
@@ -1,0 +1,36 @@
+name = "pico_examples"
+description = "Examples for Ada on the Raspberry Pi Pico"
+version = "1.3.0"
+
+authors = ["Jeremy Grosser"]
+maintainers = ["Jeremy Grosser <jeremy@synack.me>"]
+maintainers-logins = ["JeremyGrosser"]
+licenses = "BSD-3-Clause"
+tags = ["embedded", "nostd", "pico", "rp2040"]
+website = "https://pico-doc.synack.me/"
+auto-gpr-with=false
+project-files = [
+    "adc_continuous/adc_continuous.gpr",
+    "adc_hello/adc_hello.gpr",
+    "blink/blink.gpr",
+    "gpio_interrupts/gpio_interrupts.gpr",
+    "pimoroni_audio_pack/pimoroni_audio_pack.gpr",
+    "pimoroni_rgb_keypad/pimoroni_rgb_keypad.gpr",
+    "pimoroni_rgb_keypad_interrupt/pimoroni_rgb_keypad_interrupt.gpr",
+    "pio_assemble/pio_assemble.gpr",
+    "pio_blink/pio_blink.gpr",
+    "pwm/pwm.gpr",
+    "rtc/rtc.gpr",
+    "spi_loopback/spi_loopback.gpr",
+    "timer/timer.gpr",
+    "uart_echo/uart_echo.gpr",
+    "usb_echo/usb_echo.gpr",
+    "ws2812_demo/ws2812_demo.gpr"]
+
+[[depends-on]]
+pico_bsp = "^1.3"
+
+[origin]
+commit = "40af5946a47e7823bbb8c61a135aab34b09fa6fd"
+url = "git+https://github.com/JeremyGrosser/pico_examples.git"
+

--- a/index/rp/rp2040_hal/rp2040_hal-1.3.0.toml
+++ b/index/rp/rp2040_hal/rp2040_hal-1.3.0.toml
@@ -1,0 +1,28 @@
+name = "rp2040_hal"
+description = "Drivers and HAL for the RP2040 micro-controller family"
+version = "1.3.0"
+licenses = "BSD-3-Clause"
+
+authors = ["Jeremy Grosser"]
+maintainers = ["Jeremy Grosser <jeremy@synack.me>"]
+maintainers-logins = ["JeremyGrosser"]
+tags = ["embedded", "nostd", "rp2040", "raspberrypi", "drivers"]
+website = "https://pico-doc.synack.me/"
+
+[[depends-on]]
+cortex_m = "~0.3"
+hal = "~0.1"
+usb_embedded = "~0.2"
+gnat_arm_elf = "^11.2"
+
+[configuration.variables]
+Flash_Chip = {type = "Enum",  values = ["w25qxx", "generic_qspi", "generic_03"], default = "w25qxx"}
+Use_Startup = {type = "Boolean", default = true}
+
+[configuration.values]
+atomic.Backend = "armv6m"
+
+[origin]
+commit = "5d7da6115ffc0b9efa09b4b0c3ff7c980feae9a7"
+url = "git+https://github.com/JeremyGrosser/rp2040_hal.git"
+


### PR DESCRIPTION
pico_bsp and pico_examples depend on new features in rp2040_hal, so everything got a version bump with this release. @mosteo I got a little fancy with the depends-on version strings, please make sure I did it right.