### PR TITLE
Retrieve sources with `-q` to reduce git output

### DIFF
--- a/scripts/gh-build-crate.sh
+++ b/scripts/gh-build-crate.sh
@@ -154,7 +154,7 @@ for file in $CHANGES; do
       echo SKIPPING BUILD for SYSTEM crate, FETCHING only
    fi
 
-   alr -d get $milestone
+   alr -d -q get $milestone
 
    if $is_system; then
       echo DETECTING INSTALLED PACKAGE via crate $milestone


### PR DESCRIPTION
Silence the retrieval of crates so git verbosity doesn't difficult reading logs. Errors will be output anyway due to `-g`.

Tested in https://github.com/mosteo/alire-index/pull/46