### PR TITLE
Add parse_args 0.9.0

### DIFF
--- a/index/pa/parse_args/parse_args-0.9.0.toml
+++ b/index/pa/parse_args/parse_args-0.9.0.toml
@@ -1,0 +1,15 @@
+name = "parse_args"
+description = "An Ada 2012 package to parse command line arguments and options"
+version = "0.9.0"
+website = "https://github.com/jhumphry/parse_args"
+licenses = "ISC"
+tags = ["cli", "command-line"]
+
+authors = ["James Humphry"]
+maintainers = ["James Humphry <alire@binecho.co.uk>"]
+maintainers-logins = ["jhumphry"]
+
+[origin]
+commit = "635f9e4f5318dccd535ca889d744b1053ab2362e"
+url = "git+https://github.com/jhumphry/parse_args.git"
+


### PR DESCRIPTION
parse_args is an Ada 2012 package that provides simple command-line argument parsing. It was inspired by the argparse module in Python, but it is not (quite) as ambitious.