### PR TITLE
Update apdf-5.0.0.toml

### DIFF
--- a/index/ap/apdf/apdf-5.0.0.toml
+++ b/index/ap/apdf/apdf-5.0.0.toml
@@ -1,15 +1,18 @@
-description = "Standalone, portable package for producing dynamically PDF documents"
+description = "Portable package for producing dynamically PDF documents"
 name = "apdf"
 version = "5.0.0"
 authors = ["Gautier de Montmollin"]
 licenses = "MIT"
 maintainers = ["fabien.chouteau@gmail.com"]
 maintainers-logins = ["zertovitch", "Fabien-Chouteau"]
-project-files = ["pdf_out_gnat.gpr"]
+project-files = ["pdf_out_gnat_w_gid.gpr"]
 
 [gpr-externals]
-Build_Mode = ["Debug", "Fast"]
+PDF_Build_Mode = ["Debug", "Fast"]
+
+[[depends-on]]
+gid = ">=9.0.0"
 
 [origin]
-url = "https://sourceforge.net/projects/apdf/files/apdf_005.zip"
-hashes = ["sha512:ded04cdfe00628ed96d5d933f9447af4130902b0ae45b0d5dfbd3db70ca71b55d73f4adfb37ad29a68ce66eeec3ba4a5a49466f2ad56ceff8e8629c70c0f2604"]
+url = "https://sourceforge.net/projects/apdf/files/apdf_005_r3.zip"
+hashes = ["sha512:dbe27598986b1744b024803348350e48b9fe14a14b4137796b3bf12fc98e400b45fd16dc3902a5ffbfa407552131bec072c287444889d5984ade6ba6d2d981cf"]


### PR DESCRIPTION
Upgrade to release #3 of Ada PDF Writer 005.
Using an Alire-friendly project file (with-ing the GID project), fixed for recent GNAT's incremental compilation.
Build scenario has "PDF_" prefixed in order not to mix up with other projects.