### PR TITLE
rp2040_hal, pico_bsp, pico_examples 1.5.0

### DIFF
--- a/index/pi/pico_bsp/pico_bsp-1.5.0.toml
+++ b/index/pi/pico_bsp/pico_bsp-1.5.0.toml
@@ -1,0 +1,22 @@
+name = "pico_bsp"
+description = "Board support package for Raspberry Pi Pico"
+version = "1.5.0"
+licenses = "BSD-3-Clause"
+
+authors = ["Jeremy Grosser"]
+maintainers = ["Jeremy Grosser <jeremy@synack.me>"]
+maintainers-logins = ["JeremyGrosser"]
+tags = ["embedded", "nostd", "raspberrypi", "pico", "rp2040", "bsp"]
+website = "https://pico-doc.synack.me/"
+
+[[depends-on]]
+hal = "~0.1"
+rp2040_hal = "^1.5"
+
+[configuration.values]
+rp2040_hal.Flash_Chip = "w25qxx"
+
+[origin]
+commit = "22a7257552168a489f514bc4da65cbc641985b60"
+url = "git+https://github.com/JeremyGrosser/pico_bsp.git"
+

--- a/index/pi/pico_examples/pico_examples-1.5.0.toml
+++ b/index/pi/pico_examples/pico_examples-1.5.0.toml
@@ -1,0 +1,39 @@
+name = "pico_examples"
+description = "Examples for Ada on the Raspberry Pi Pico"
+version = "1.5.0"
+
+authors = ["Jeremy Grosser"]
+maintainers = ["Jeremy Grosser <jeremy@synack.me>"]
+maintainers-logins = ["JeremyGrosser"]
+licenses = "BSD-3-Clause"
+tags = ["embedded", "nostd", "pico", "rp2040"]
+website = "https://pico-doc.synack.me/"
+auto-gpr-with=false
+project-files = [
+    "adc_continuous/adc_continuous.gpr",
+    "adc_hello/adc_hello.gpr",
+    "blink/blink.gpr",
+    "gpio_interrupts/gpio_interrupts.gpr",
+    "multicore/multicore.gpr",
+    "pimoroni_audio_pack/pimoroni_audio_pack.gpr",
+    "pimoroni_rgb_keypad/pimoroni_rgb_keypad.gpr",
+    "pimoroni_rgb_keypad_interrupt/pimoroni_rgb_keypad_interrupt.gpr",
+    "pio_assemble/pio_assemble.gpr",
+    "pio_blink/pio_blink.gpr",
+    "pwm/pwm.gpr",
+    "rtc/rtc.gpr",
+    "spi_loopback/spi_loopback.gpr",
+    "timer/timer.gpr",
+    "uart_echo/uart_echo.gpr",
+    "uart_interrupt/uart_interrupt.gpr",
+    "usb_echo/usb_echo.gpr",
+    "ws2812_demo/ws2812_demo.gpr"]
+
+[[depends-on]]
+pico_bsp = "^1.5"
+chests = "~0.1.1"
+
+[origin]
+commit = "2494b8fd8e66fc5805f85a2d4c391fa926786e20"
+url = "git+https://github.com/JeremyGrosser/pico_examples.git"
+

--- a/index/rp/rp2040_hal/rp2040_hal-1.5.0.toml
+++ b/index/rp/rp2040_hal/rp2040_hal-1.5.0.toml
@@ -1,0 +1,28 @@
+name = "rp2040_hal"
+description = "Drivers and HAL for the RP2040 micro-controller family"
+version = "1.5.0"
+licenses = "BSD-3-Clause"
+
+authors = ["Jeremy Grosser"]
+maintainers = ["Jeremy Grosser <jeremy@synack.me>"]
+maintainers-logins = ["JeremyGrosser"]
+tags = ["embedded", "nostd", "rp2040", "raspberrypi", "drivers"]
+website = "https://pico-doc.synack.me/"
+
+[[depends-on]]
+cortex_m = "~0.3"
+hal = "~0.1"
+usb_embedded = "~0.2"
+gnat_arm_elf = "^11.2"
+
+[configuration.variables]
+Flash_Chip = {type = "Enum",  values = ["w25qxx", "generic_qspi", "generic_03"], default = "w25qxx"}
+Use_Startup = {type = "Boolean", default = true}
+
+[configuration.values]
+atomic.Backend = "armv6m"
+
+[origin]
+commit = "fee519d49256de7ffb4ffa7820bd70b809f3a7d4"
+url = "git+https://github.com/JeremyGrosser/rp2040_hal.git"
+


### PR DESCRIPTION
[1.5.0 Release notes](https://pico-doc.synack.me/#1_5_0)

The only significant change around packaging is that pico_examples now depends on chests.