### PR TITLE
Add external crates for BLAS, LAPACK

### DIFF
--- a/index/li/libblas/libblas-external.toml
+++ b/index/li/libblas/libblas-external.toml
@@ -1,0 +1,13 @@
+description = "Basic Linear Algebra Subprograms"
+name = "libblas"
+licenses = "custom-blas-2017"
+
+authors = ["Simon Wright"]
+maintainers = ["Simon Wright <simon@pushface.org>"]
+maintainers-logins = ["simonjwright"]
+
+[[external]]
+kind="system"
+[external.origin."case(distribution)"]
+"debian|ubuntu" = ["libblas-dev"]
+# "msys2" = ["mingw-w64-x86_64-openblas"]

--- a/index/li/liblapack/liblapack-external.toml
+++ b/index/li/liblapack/liblapack-external.toml
@@ -1,0 +1,13 @@
+description = "Linear Algebra Package"
+name = "liblapack"
+licenses = "BSD-3-Clause"
+
+authors = ["Simon Wright"]
+maintainers = ["Simon Wright <simon@pushface.org>"]
+maintainers-logins = ["simonjwright"]
+
+[[external]]
+kind="system"
+[external.origin."case(distribution)"]
+"debian|ubuntu" = ["liblapack-dev"]
+# "msys2" = ["mingw-w64-x86_64-lapack"]


### PR DESCRIPTION
These only support linux; not needed on macOS, and the msys2 libraries can't
be installed because of key signing errors.

If called in on macOS there will be warnings about unsatisfied external dependency: is there a way of saying `null`? e.g. `"macos" = []`?

Tested by using a [personal index](https://github.com/simonjwright/local-alire-index) while making a crate for [GNAT Math Extensions](https://github.com/simonjwright/gnat_math_extensions). 