### PR TITLE
Fix testing of monorepo crates

### DIFF
--- a/scripts/gh-build-crate.sh
+++ b/scripts/gh-build-crate.sh
@@ -179,7 +179,7 @@ for file in $CHANGES; do
    elif $is_binary; then
       echo FETCHED BINARY crate OK
    else
-      echo FETCHED SOURCE crate OK
+      echo FETCHED SOURCE crate OK, deployed at $(alr get --dirname $milestone)
       # Enter the deployment dir
       cd $(alr get --dirname $milestone)
       echo BUILD ENVIRONMENT

--- a/scripts/gh-build-crate.sh
+++ b/scripts/gh-build-crate.sh
@@ -180,7 +180,8 @@ for file in $CHANGES; do
       echo FETCHED BINARY crate OK
    else
       echo FETCHED SOURCE crate OK
-      cd ${crate}_${version_noextras}_*
+      # Enter the deployment dir
+      cd $(alr get --dirname $milestone)
       echo BUILD ENVIRONMENT
       alr printenv
       echo BUILDING CRATE


### PR DESCRIPTION
To be merged into `stable-1.2` once the `setup-alire` action is pointing to the new `1.2` alr release.