### PR TITLE
Correct msys2 externals for libblas, liblapack

### DIFF
--- a/index/li/libblas/libblas-external.toml
+++ b/index/li/libblas/libblas-external.toml
@@ -9,5 +9,6 @@ maintainers-logins = ["simonjwright"]
 [[external]]
 kind="system"
 [external.origin."case(distribution)"]
+"macos" = []
 "debian|ubuntu" = ["libblas-dev"]
-# "msys2" = ["mingw-w64-x86_64-openblas"]
+"msys2" = ["mingw-w64-x86_64-lapack"]

--- a/index/li/liblapack/liblapack-external.toml
+++ b/index/li/liblapack/liblapack-external.toml
@@ -9,5 +9,6 @@ maintainers-logins = ["simonjwright"]
 [[external]]
 kind="system"
 [external.origin."case(distribution)"]
+"macos" = []
 "debian|ubuntu" = ["liblapack-dev"]
-# "msys2" = ["mingw-w64-x86_64-lapack"]
+"msys2" = ["mingw-w64-x86_64-lapack"]


### PR DESCRIPTION
Following the very helpful comments on #517, this update resulted in a successful build & run with windows-latest.

I’m not sure about the "empty origin for macos" part (the point being, that anyone developing on macOS will have these libraries installed as part of the SDK, so I wanted to avoid warnings about unsatisfied external references).
   
  * index/li/libblas/libblas-external.toml: uncomment the msys2 origin
      and make it to lapack. The reason is that we require libblas.dll,
      and this isn't provided by openblas (lapack provides both).
      Also, add an empty origin for macos.
  * index/li/liblapack/liblapack-external.toml: uncomment the msys2
      origin.
      Also, add an empty origin for macos.