### PR TITLE
gnat_math_extensions 1.1.0

### DIFF
--- a/index/gn/gnat_math_extensions/gnat_math_extensions-1.1.0.toml
+++ b/index/gn/gnat_math_extensions/gnat_math_extensions-1.1.0.toml
@@ -1,0 +1,22 @@
+name = "gnat_math_extensions"
+description = "Eigenvalues, eigenvectors for non-symmetric, non-Hermitian matrices"
+website = "https://github.com/simonjwright/gnat_math_extensions"
+version = "1.1.0"
+licenses= "GPL-3.0-or-later WITH GCC-exception-3.1"
+
+authors = ["Simon Wright"]
+maintainers = ["Simon Wright <simon@pushface.org>"]
+maintainers-logins = ["simonjwright"]
+
+project-files = ["gnat_math_extensions.gpr"]
+
+tags = ["matrices", "blas", "lapack"]
+
+[[depends-on]]
+  "libblas" = "*"
+  "liblapack" = "*"
+
+[origin]
+commit = "e1f68c35cfb4539450341cede99ffc980510219c"
+url = "git+https://github.com/simonjwright/gnat_math_extensions.git"
+


### PR DESCRIPTION
This project started in 2010.

It provides additional matrix capabilities beyond those defined in the Standard Library (Annex G of the ARM).

The Standard defines real and complex matrix and vector operations. Not every possible operation is supported, so for example only symmetric real or [hermitian](http://en.wikipedia.org/wiki/Hermitian_matrix) complex matrices can be solved.

The implementations, which are only for GNAT, are in the form of bindings to the [LAPACK](https://www.netlib.org/lapack) and [BLAS](https://www.netlib.org/blas/") libraries which are widely available if not already provided on all operating systems.