### PR TITLE
nrf5x-hal-0.1.0: fix dependencies

### DIFF
--- a/index/mi/microbit_examples/microbit_examples-0.1.0.toml
+++ b/index/mi/microbit_examples/microbit_examples-0.1.0.toml
@@ -102,7 +102,7 @@ tags = ["embedded", "nostd", "microbit", "nrf51"]
 auto-gpr-with=false # User has to select only one project file
 
 [[depends-on]]
-microbit_bsp = "^0.1.0"
+microbit_bsp = "~0.1.0"
 
 [gpr-set-externals]
 MICROBIT_BSP_RUNTIME_CHECKS="enabled"

--- a/index/nr/nrf5x_hal/nrf5x_hal-0.1.0.toml
+++ b/index/nr/nrf5x_hal/nrf5x_hal-0.1.0.toml
@@ -11,8 +11,9 @@ tags = ["embedded", "nostd", "nrf51", "nrf52", "nordic", "drivers", "ble"]
 auto-gpr-with=false # User has to select only one project file
 
 [[depends-on]]
-cortex_m = "^0.2.0"
-hal = "^0.1.0"
+cortex_m = "~0.2.0"
+hal = "~0.1.0"
+gnat_arm_elf = "^11.2'
 
 [origin]
 commit = "0cf20efac2d0a64ed22844edbfcdd3acbbcdb1cc"

--- a/index/nr/nrf5x_hal/nrf5x_hal-0.1.0.toml
+++ b/index/nr/nrf5x_hal/nrf5x_hal-0.1.0.toml
@@ -13,7 +13,7 @@ auto-gpr-with=false # User has to select only one project file
 [[depends-on]]
 cortex_m = "~0.2.0"
 hal = "~0.1.0"
-gnat_arm_elf = "^11.2'
+gnat_arm_elf = "^11.2"
 
 [origin]
 commit = "0cf20efac2d0a64ed22844edbfcdd3acbbcdb1cc"


### PR DESCRIPTION
`~` was intended here and required since `cortex_m=0.4.0` is breaking the builds.