### PR TITLE
Add a bit more macOS support for gnatcoll friends.

### DIFF
--- a/index/gn/gnatcoll_python3/gnatcoll_python3-21.0.0.toml
+++ b/index/gn/gnatcoll_python3/gnatcoll_python3-21.0.0.toml
@@ -17,8 +17,14 @@ LIBRARY_TYPE = ["static", "relocatable", "static-pic"]
 "debian|ubuntu" = { C_INCLUDE_PATH.append = "${DISTRIB_ROOT}/usr/include/python3.7/:${DISTRIB_ROOT}/usr/include/python3.8/"}
 msys2 = { C_INCLUDE_PATH.append = "${DISTRIB_ROOT}/mingw64/include/python3.8/" }
 
+[environment.'case(os)']
+macos = { C_INCLUDE_PATH.append = "/opt/local/Library/Frameworks/Python.framework/Versions/3.9/include/python3.9" }
+
 [available.'case(distribution)']
 'debian|ubuntu|msys2' = true
+
+[available.'case(os)']
+'macos' = true
 '...' = false
 
 [[depends-on]]

--- a/index/gn/gnatcoll_python3/gnatcoll_python3-21.0.0.toml
+++ b/index/gn/gnatcoll_python3/gnatcoll_python3-21.0.0.toml
@@ -17,9 +17,6 @@ LIBRARY_TYPE = ["static", "relocatable", "static-pic"]
 "debian|ubuntu" = { C_INCLUDE_PATH.append = "${DISTRIB_ROOT}/usr/include/python3.7/:${DISTRIB_ROOT}/usr/include/python3.8/"}
 msys2 = { C_INCLUDE_PATH.append = "${DISTRIB_ROOT}/mingw64/include/python3.8/" }
 
-[environment.'case(os)']
-macos = { C_INCLUDE_PATH.append = "/opt/local/Library/Frameworks/Python.framework/Versions/3.9/include/python3.9" }
-
 [available.'case(distribution)']
 'debian|ubuntu|msys2' = true
 

--- a/index/li/liblzma/liblzma-external.toml
+++ b/index/li/liblzma/liblzma-external.toml
@@ -13,3 +13,6 @@ kind = "system"
 kind = "version-output"
 version-command = [ "pkg-config", "--modversion", "liblzma" ]
 version-regexp = "([\\d\\.]+)"
+[external.available.'case(os)']
+macos = true
+'...' = false

--- a/index/li/liblzma/liblzma-external.toml
+++ b/index/li/liblzma/liblzma-external.toml
@@ -8,3 +8,8 @@ maintainers-logins = ["Fabien-Chouteau"]
 kind = "system"
 [external.origin."case(distribution)"]
 "debian|ubuntu" = ["liblzma-dev"]
+
+[[external]]
+kind = "version-output"
+version-command = [ "pkg-config", "--modversion", "liblzma" ]
+version-regexp = "([\\d\\.]+)"

--- a/index/li/libpython3dev/libpython3dev-external.toml
+++ b/index/li/libpython3dev/libpython3dev-external.toml
@@ -9,3 +9,8 @@ kind = "system"
 [external.origin."case(distribution)"]
 "debian|ubuntu" = ["libpython3-dev"]
 msys2 = ["mingw-w64-x86_64-python"]
+
+[[external]]
+kind = "version-output"
+version-command = [ "python3-config", "--include" ]
+version-regexp = "include/python([\\d\\.]+)"

--- a/index/li/libpython3dev/libpython3dev-external.toml
+++ b/index/li/libpython3dev/libpython3dev-external.toml
@@ -14,3 +14,6 @@ msys2 = ["mingw-w64-x86_64-python"]
 kind = "version-output"
 version-command = [ "python3-config", "--include" ]
 version-regexp = "include/python([\\d\\.]+)"
+[external.available.'case(os)']
+macos = true
+'...' = false

--- a/index/li/libreadline/libreadline-external.toml
+++ b/index/li/libreadline/libreadline-external.toml
@@ -14,3 +14,6 @@ msys2 = ["mingw-w64-x86_64-readline"]
 kind = "version-output"
 version-command = [ "pkg-config", "--modversion", "readline" ]
 version-regexp = "([\\d\\.]+)"
+[external.available.'case(os)']
+macos = true
+'...' = false

--- a/index/li/libreadline/libreadline-external.toml
+++ b/index/li/libreadline/libreadline-external.toml
@@ -9,3 +9,8 @@ kind = "system"
 [external.origin."case(distribution)"]
 "debian|ubuntu" = ["libreadline-dev"]
 msys2 = ["mingw-w64-x86_64-readline"]
+
+[[external]]
+kind = "version-output"
+version-command = [ "pkg-config", "--modversion", "readline" ]
+version-regexp = "([\\d\\.]+)"

--- a/index/zl/zlib/zlib-external.toml
+++ b/index/zl/zlib/zlib-external.toml
@@ -15,3 +15,6 @@ msys2 = ["mingw-w64-x86_64-zlib"]
 kind = "version-output"
 version-command = [ "pkg-config", "--modversion", "zlib" ]
 version-regexp = "([\\d\\.]+)"
+[external.available.'case(os)']
+macos = true
+'...' = false

--- a/index/zl/zlib/zlib-external.toml
+++ b/index/zl/zlib/zlib-external.toml
@@ -10,3 +10,8 @@ kind = "system"
 [external.origin."case(distribution)"]
 "debian|ubuntu" = ["zlib1g-dev"]
 msys2 = ["mingw-w64-x86_64-zlib"]
+
+[[external]]
+kind = "version-output"
+version-command = [ "pkg-config", "--modversion", "zlib" ]
+version-regexp = "([\\d\\.]+)"


### PR DESCRIPTION
Add a bit more macOS support for gnatcoll, gnatcoll_iconv, gnatcoll_sql, gnatcoll_sqlite, gnatcoll_zlib, gnatcoll_syslog, gnatcoll_readline, gnatcoll_python3, gnatcoll_lzma.
Tested with MacPorts (Python 3.9, lzma, zlib, readline).