### PR TITLE
Fix detection of compiler crates in test script

### DIFF
--- a/scripts/gh-build-crate.sh
+++ b/scripts/gh-build-crate.sh
@@ -128,7 +128,7 @@ for file in $CHANGES; do
    if grep -iq 'gnat_' <<< $solution && ! grep -iq 'gnat_external' <<< $solution; then
       gnat_dep=$(grep -E -o '^   gnat_[a-z0-9_]*=\S*' <<< $solution | tail -1 | xargs)
       gnat_dep=${gnat_dep:-gnat_native}
-      if $(alr show $gnat_dep | grep -q 'Provides: gnat='); then
+      if alr show $gnat_dep | grep 'Provides: gnat=' >/dev/null; then
          echo "INSTALLING indexed toolchain compatible with $gnat_dep"
          alr toolchain --select $gnat_dep gprbuild
          # -E for regex, -o for only the matched part, xargs to trim space

--- a/scripts/gh-build-crate.sh
+++ b/scripts/gh-build-crate.sh
@@ -128,11 +128,15 @@ for file in $CHANGES; do
    if grep -iq 'gnat_' <<< $solution && ! grep -iq 'gnat_external' <<< $solution; then
       gnat_dep=$(grep -E -o '^   gnat_[a-z0-9_]*=\S*' <<< $solution | tail -1 | xargs)
       gnat_dep=${gnat_dep:-gnat_native}
-      echo "INSTALLING indexed gprbuild compatible with $gnat_dep"
-      alr toolchain --select $gnat_dep gprbuild
-      # -E for regex, -o for only the matched part, xargs to trim space
-      # We must give both the gnat in the solution and gprbuild, so both are compatible
-      # Even if we default to gnat_native, that would select the appropriate gprbuild
+      if $(alr show $gnat_dep | grep -q 'Provides: gnat='); then
+         echo "INSTALLING indexed toolchain compatible with $gnat_dep"
+         alr toolchain --select $gnat_dep gprbuild
+         # -E for regex, -o for only the matched part, xargs to trim space
+         # We must give both the gnat in the solution and gprbuild, so both are compatible
+         # Even if we default to gnat_native, that would select the appropriate gprbuild
+      else
+         echo "Dependency $gnat_dep is not a GNAT compiler dependency, treating it as a regular crate"
+      fi
    fi
 
    # Detect whether the crate is binary to skip build


### PR DESCRIPTION
We were blindly assuming that any  `gnat_*` crate was a compiler. Now we verify that such a crate actually fulfills the `gnat` virtual dependency.