### PR TITLE
Disable git check in testing script

### DIFF
--- a/scripts/gh-build-crate.sh
+++ b/scripts/gh-build-crate.sh
@@ -9,6 +9,9 @@ set -o nounset
 # Ensure all alr runs are non-interactive and able to output unexpected errors
 alias alr="alr -d -n"
 
+# Disable check for ownership that sometimes confuses docker-run git
+git config --global --add safe.directory '*'
+
 # See whats happening
 git log --graph --decorate --pretty=oneline --abbrev-commit --all | head -30
 

--- a/scripts/gh-build-crate.sh
+++ b/scripts/gh-build-crate.sh
@@ -10,6 +10,8 @@ set -o nounset
 alias alr="alr -d -n"
 
 # Disable check for ownership that sometimes confuses docker-run git
+# Also, Github is not vulnerable to iCVE-2022-24765/CVE-2022-24767, see 
+# https://github.blog/2022-04-12-git-security-vulnerability-announced/
 git config --global --add safe.directory '*'
 
 # See whats happening


### PR DESCRIPTION
Out of the blue (after updating the docker image really) some docker images have started to fail because there seems to be a user mismatch between the host machine and docker guests. This is for a vulnerability that doesn't affect github so the git check can be safely disabled: 

https://github.blog/2022-04-12-git-security-vulnerability-announced/