### PR TITLE
Fix templates_parser to work with GCC 12

### DIFF
--- a/index/te/templates_parser/templates_parser-22.0.0.toml
+++ b/index/te/templates_parser/templates_parser-22.0.0.toml
@@ -23,6 +23,7 @@ TP_XMLADA = ["Installed", "Disabled"]
 
 [gpr-set-externals]
 TP_XMLADA = "Installed"
+PRJ_BUILD = "Release"
 
 [environment]
 ADAFLAGS.set = "-gnaty-d" # Disable no DOS line terminators check


### PR DESCRIPTION
Force `PRJ_BUILD` to `Release` to avoid `-gnatwe` and compilation issue:

```
templates_parser.adb:2093:55: warning: pragma Unreferenced given for "Next_Last" [enabled by default]
```