### PR TITLE
Added Arch Linux for Postgresql external dependency

### DIFF
--- a/index/po/postgresql/postgresql-external.toml
+++ b/index/po/postgresql/postgresql-external.toml
@@ -7,5 +7,5 @@ maintainers-logins = ["Fabien-Chouteau"]
 [[external]]
 kind = "system"
 [external.origin."case(distribution)"]
-"debian|ubuntu" = ["postgresql"]
+"debian|ubuntu|arch" = ["postgresql"]
 msys2 = ["mingw-w64-x86_64-postgresql"]


### PR DESCRIPTION
Tested on Arch up to date on 07/27/2022