### PR TITLE
Add crate for new version of Ada LZMA 1.1.2 thin library

### DIFF
--- a/index/lz/lzmada/lzmada-1.1.2.toml
+++ b/index/lz/lzmada/lzmada-1.1.2.toml
@@ -1,0 +1,26 @@
+description = "Ada LZMA Library Binding"
+long-description = "A very thin Ada binding for the LZMA compression library"
+name = "lzmada"
+version = "1.1.2"
+licenses = "MIT"
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+authors = ["Stephane.Carrez@gmail.com"]
+project-files = [".alire/lzmada.gpr"]
+tags = ["compression", "lzma"]
+website = "https://gitlab.com/stcarrez/ada-lzma"
+
+[gpr-externals]
+BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
+LZMA_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+
+[[depends-on]]
+liblzma = "*"
+
+[configuration]
+disabled = true
+
+[origin]
+commit = "f74f024479ac4ea8949421dede73eb319bdb073a"
+url = "git+https://gitlab.com/stcarrez/ada-lzma.git"
+


### PR DESCRIPTION
This pull request updates the Ada LZMA crate with the latest 1.1.2 version.