### PR TITLE
Add crate for the new Ada Utility 2.5.0 library

### DIFF
--- a/index/ut/utilada/utilada-2.5.0.toml
+++ b/index/ut/utilada/utilada-2.5.0.toml
@@ -15,9 +15,6 @@ BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
 UTIL_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
 UTIL_OS = ["win32", "win64", "linux32", "linux64", "macos64", "netbsd32", "netbsd64", "freebsd32", "freebsd64"]
 
-[gpr-set-externals]
-BUILD = "distrib"
-UTIL_LIBRARY_TYPE = "static"
 [gpr-set-externals."case(os)".linux."case(word-size)".bits-32]
 UTIL_OS = "linux32"
 

--- a/index/ut/utilada/utilada-2.5.0.toml
+++ b/index/ut/utilada/utilada-2.5.0.toml
@@ -1,0 +1,41 @@
+description = "Utility Library with streams, processes, logs, serialization, encoders"
+long-description = "\n[![Build Status](https://img.shields.io/jenkins/s/https/jenkins.vacs.fr/Ada-Util.svg)](https://jenkins.vacs.fr/job/Ada-Util/)\n[![Test Status](https://img.shields.io/jenkins/t/https/jenkins.vacs.fr/Ada-Util.svg)](https://jenkins.vacs.fr/job/Ada-Util/)\n[![codecov](https://codecov.io/gh/stcarrez/ada-util/branch/master/graph/badge.svg)](https://codecov.io/gh/stcarrez/ada-util)\n\nThis Ada05 library contains various utility packages for building\nAda05 applications.  This includes:\n\n* A logging framework close to Java log4j framework,\n* Support for properties\n* A serialization/deserialization framework for XML, JSON, CSV\n* Ada beans framework\n* Encoding/decoding framework (Base16, Base64, SHA, HMAC-SHA, AES-256)\n* A composing stream framework (raw, files, buffers, pipes, sockets)\n* Several concurrency tools (reference counters, counters, pools, fifos, arrays)\n* Process creation and pipes\n* Support for loading shared libraries (on Windows or Unix)\n* HTTP client library on top of CURL or AWS\n\nAda Util also provides a small test utility library on top of\nAhven or AUnit to help in writing unit tests.  Ahven is the default testing\nframework as it provides better reports.\n\n## Documentation\n\n* [Ada Utility Library Programmer's Guide](https://ada-util.readthedocs.io/en/latest/)\n\n"
+name = "utilada"
+version = "2.5.0"
+authors = ["Stephane.Carrez@gmail.com"]
+licenses = "Apache-2.0"
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+project-files = [".alire/utilada_conf.gpr", "utilada_core.gpr", "utilada_base.gpr", "utilada_sys.gpr"]
+tags = ["logging", "processes", "streams", "json", "beans", "encoders", "decoders"]
+website = "https://gitlab.com/stcarrez/ada-util"
+
+[gpr-externals]
+BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
+UTIL_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+UTIL_OS = ["win32", "win64", "linux32", "linux64", "macos64", "netbsd32", "netbsd64", "freebsd32", "freebsd64"]
+
+[gpr-set-externals]
+BUILD = "distrib"
+UTIL_LIBRARY_TYPE = "static"
+[gpr-set-externals."case(os)".linux."case(word-size)".bits-32]
+UTIL_OS = "linux32"
+
+[gpr-set-externals."case(os)".linux."case(word-size)".bits-64]
+UTIL_OS = "linux64"
+
+[gpr-set-externals."case(os)".macos]
+UTIL_OS = "macos64"
+[gpr-set-externals."case(os)".windows."case(word-size)".bits-32]
+UTIL_OS = "win32"
+
+[gpr-set-externals."case(os)".windows."case(word-size)".bits-64]
+UTIL_OS = "win64"
+
+[configuration]
+disabled = true
+
+[origin]
+commit = "f65f9ba9cd38c57d11b1248e17207338026b49af"
+url = "git+https://gitlab.com/stcarrez/ada-util.git"
+

--- a/index/ut/utilada_aws/utilada_aws-2.5.0.toml
+++ b/index/ut/utilada_aws/utilada_aws-2.5.0.toml
@@ -1,0 +1,31 @@
+description = "Utility Library REST support on top of AWS"
+long-description = "\n[![Build Status](https://img.shields.io/jenkins/s/https/jenkins.vacs.fr/Ada-Util.svg)](https://jenkins.vacs.fr/job/Ada-Util/)\n[![Test Status](https://img.shields.io/jenkins/t/https/jenkins.vacs.fr/Ada-Util.svg)](https://jenkins.vacs.fr/job/Ada-Util/)\n[![codecov](https://codecov.io/gh/stcarrez/ada-util/branch/master/graph/badge.svg)](https://codecov.io/gh/stcarrez/ada-util)\n\n\nThis small library provides an HTTP backend on top of AWS.\nIt is can be used by the `Util.Http` package.\n\nAn alternate HTTP backend is provided by CURL with utilada_curl.\n\n"
+name = "utilada_aws"
+version = "2.5.0"
+authors = ["Stephane.Carrez@gmail.com"]
+licenses = "Apache-2.0"
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+project-files = [".alire/aws/utilada_aws.gpr"]
+tags = ["web", "http"]
+website = "https://gitlab.com/stcarrez/ada-util"
+
+[[depends-on]]
+utilada = "^2.5.0"
+aws = "~21.0"
+
+[gpr-externals]
+BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
+UTIL_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+UTIL_AWS_IMPL = ["1", "2", "3"]
+
+[gpr-set-externals]
+UTIL_AWS_IMPL = "2"
+
+[configuration]
+disabled = true
+
+[origin]
+commit = "f65f9ba9cd38c57d11b1248e17207338026b49af"
+url = "git+https://gitlab.com/stcarrez/ada-util.git"
+

--- a/index/ut/utilada_curl/utilada_curl-2.5.0.toml
+++ b/index/ut/utilada_curl/utilada_curl-2.5.0.toml
@@ -1,0 +1,27 @@
+description = "Utility Library REST support on top of CURL"
+long-description = "\n[![Build Status](https://img.shields.io/jenkins/s/https/jenkins.vacs.fr/Ada-Util.svg)](https://jenkins.vacs.fr/job/Ada-Util/)\n[![Test Status](https://img.shields.io/jenkins/t/https/jenkins.vacs.fr/Ada-Util.svg)](https://jenkins.vacs.fr/job/Ada-Util/)\n[![codecov](https://codecov.io/gh/stcarrez/ada-util/branch/master/graph/badge.svg)](https://codecov.io/gh/stcarrez/ada-util)\n\n\nThis small library provides an HTTP backend on top of CURL.\nIt is can be used by the `Util.Http` package.\n\nAn alternate HTTP backend is provided by AWS with utilada_aws.\n\n"
+name = "utilada_curl"
+version = "2.5.0"
+authors = ["Stephane.Carrez@gmail.com"]
+licenses = "Apache-2.0"
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+project-files = ["utilada_curl.gpr"]
+tags = ["web", "http", "rest"]
+website = "https://gitlab.com/stcarrez/ada-util"
+
+[[depends-on]]
+utilada = "^2.5.0"
+curl = "*"
+
+[gpr-externals]
+BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
+UTIL_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+
+[configuration]
+disabled = true
+
+[origin]
+commit = "f65f9ba9cd38c57d11b1248e17207338026b49af"
+url = "git+https://gitlab.com/stcarrez/ada-util.git"
+

--- a/index/ut/utilada_unit/utilada_unit-2.5.0.toml
+++ b/index/ut/utilada_unit/utilada_unit-2.5.0.toml
@@ -1,0 +1,26 @@
+description = "Utility Library testing framework with Ahven"
+long-description = "\n[![Build Status](https://img.shields.io/jenkins/s/https/jenkins.vacs.fr/Ada-Util.svg)](https://jenkins.vacs.fr/job/Ada-Util/)\n[![Test Status](https://img.shields.io/jenkins/t/https/jenkins.vacs.fr/Ada-Util.svg)](https://jenkins.vacs.fr/job/Ada-Util/)\n[![codecov](https://codecov.io/gh/stcarrez/ada-util/branch/master/graph/badge.svg)](https://codecov.io/gh/stcarrez/ada-util)\n\nThis library provides a testing framework on top of Ahven.\nIt provides various testing helper operations to help in\nwriting unit tests.\n\n"
+name = "utilada_unit"
+version = "2.5.0"
+authors = ["Stephane.Carrez@gmail.com"]
+licenses = "Apache-2.0"
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+project-files = [".alire/unit/utilada_unit.gpr"]
+tags = ["testing"]
+website = "https://gitlab.com/stcarrez/ada-util"
+
+[[depends-on]]
+utilada = "^2.5.0"
+
+[gpr-externals]
+BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
+UTIL_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+
+[configuration]
+disabled = true
+
+[origin]
+commit = "f65f9ba9cd38c57d11b1248e17207338026b49af"
+url = "git+https://gitlab.com/stcarrez/ada-util.git"
+

--- a/index/ut/utilada_xml/utilada_xml-2.5.0.toml
+++ b/index/ut/utilada_xml/utilada_xml-2.5.0.toml
@@ -1,0 +1,27 @@
+description = "Utility Library serialization with XML/Ada"
+long-description = "\n[![Build Status](https://img.shields.io/jenkins/s/https/jenkins.vacs.fr/Ada-Util.svg)](https://jenkins.vacs.fr/job/Ada-Util/)\n[![Test Status](https://img.shields.io/jenkins/t/https/jenkins.vacs.fr/Ada-Util.svg)](https://jenkins.vacs.fr/job/Ada-Util/)\n[![codecov](https://codecov.io/gh/stcarrez/ada-util/branch/master/graph/badge.svg)](https://codecov.io/gh/stcarrez/ada-util)\n\nThis library provides a serialization framework on top of XML/Ada for\nAda Utility Library.\n\n"
+name = "utilada_xml"
+version = "2.5.0"
+authors = ["Stephane.Carrez@gmail.com"]
+licenses = "Apache-2.0"
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+project-files = [".alire/xml/utilada_xml.gpr"]
+tags = ["xml", "serialization"]
+website = "https://gitlab.com/stcarrez/ada-util"
+
+[[depends-on]]
+utilada = "^2.5.0"
+xmlada = "any"
+
+[gpr-externals]
+BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
+UTIL_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+
+[configuration]
+disabled = true
+
+[origin]
+commit = "f65f9ba9cd38c57d11b1248e17207338026b49af"
+url = "git+https://gitlab.com/stcarrez/ada-util.git"
+


### PR DESCRIPTION
This is an update of Ada Utility Library. I've have not included yet the `utilada_lzma` because it needs to have the `lzmada` 1.1.2 integrated first.
