### PR TITLE
Drop setting of `LIBRARY_TYPE`

### DIFF
--- a/index/ad/ada_language_server/ada_language_server-22.0.0.toml
+++ b/index/ad/ada_language_server/ada_language_server-22.0.0.toml
@@ -9,9 +9,6 @@ maintainers-logins = ["reznikmm"]
 project-files = ["gnat/lsp_server.gpr"]
 tags = ["lsp", "vscode"]
 
-[gpr-set-externals]
-LIBRARY_TYPE = "static"
-
 [environment]
 ADA_PROJECT_PATH.set= "${CRATE_ROOT}/subprojects/stubs"
 


### PR DESCRIPTION
This lets the user choose between static/relocatable versions of ALS and fixes
[an issue](https://github.com/AdaCore/ada_language_server/issues/1026)
with system compiler.