### PR TITLE
crate for AVR standard library

### DIFF
--- a/index/av/avrada_lib/avrada_lib-2.0.0-pre_1.toml
+++ b/index/av/avrada_lib/avrada_lib-2.0.0-pre_1.toml
@@ -1,0 +1,32 @@
+name = "avrada_lib"
+description = "Library of drivers for AVR microcontrollers"
+version = "2.0.0-pre_1"
+
+authors = ["Rolf Ebert"]
+maintainers = ["Rolf Ebert <rolf.ebert.gcc@gmx.de>"]
+maintainers-logins = ["RREE"]
+licenses = "GPL-2.0-or-later WITH GCC-exception-3.1"
+website = "https://sourceforge.net/projects/avr-ada/"
+tags = ["avr", "embedded"]
+
+[configuration.variables]
+# If your program uses AVR.Real_Time.Timing_Events you can either
+# handle them in your main loop (False) or during the 1ms clock tick
+# of Timer0 (True). Defaults to false as most applications do not use
+# timing events.
+Process_Timing_Events_In_Ticks = {type = "Boolean", default = false}
+
+# Serial/UART receive mode can either be by polling the Rx bit or by
+# interrupt.  Interrupt mode is only partly implemented.
+UART_Receive_Mode = {type = "Enum", values = ["polled", "interrupt"], default = "polled"}
+
+[[depends-on]]
+gnat_avr_elf = "^11"
+avrada_rts = "^2.0.0"
+avrada_mcu = "^2.0.0"
+
+
+[origin]
+commit = "528aaa65aa77f0788ba677983ffb67cc2fd9e60e"
+url = "git+https://github.com/RREE/AVRAda_Lib.git"
+

--- a/index/av/avrada_lib/avrada_lib-2.0.0.toml
+++ b/index/av/avrada_lib/avrada_lib-2.0.0.toml
@@ -1,6 +1,6 @@
 name = "avrada_lib"
 description = "Library of drivers for AVR microcontrollers"
-version = "2.0.0-pre_1"
+version = "2.0.0"
 
 authors = ["Rolf Ebert"]
 maintainers = ["Rolf Ebert <rolf.ebert.gcc@gmx.de>"]
@@ -27,6 +27,6 @@ avrada_mcu = "^2.0.0"
 
 
 [origin]
-commit = "528aaa65aa77f0788ba677983ffb67cc2fd9e60e"
+commit = "38be63691debb2b732dd95b4ed4bdba35bc09b17"
 url = "git+https://github.com/RREE/AVRAda_Lib.git"
 

--- a/index/av/avrada_lib/avrada_lib-2.0.1.toml
+++ b/index/av/avrada_lib/avrada_lib-2.0.1.toml
@@ -1,0 +1,32 @@
+name = "avrada_lib"
+description = "Library of drivers for AVR microcontrollers"
+version = "2.0.1"
+
+authors = ["Rolf Ebert"]
+maintainers = ["Rolf Ebert <rolf.ebert.gcc@gmx.de>"]
+maintainers-logins = ["RREE"]
+licenses = "GPL-2.0-or-later WITH GCC-exception-3.1"
+website = "https://sourceforge.net/projects/avr-ada/"
+tags = ["avr", "embedded", "drivers"]
+
+[configuration.variables]
+# If your program uses AVR.Real_Time.Timing_Events you can either
+# handle them in your main loop (False) or during the 1ms clock tick
+# of Timer0 (True). Defaults to false as most applications do not use
+# timing events.
+Process_Timing_Events_In_Ticks = {type = "Boolean", default = false}
+
+# Serial/UART receive mode can either be by polling the Rx bit or by
+# interrupt.  Interrupt mode is only partly implemented.
+UART_Receive_Mode = {type = "Enum", values = ["polled", "interrupt"], default = "polled"}
+
+[[depends-on]]
+gnat_avr_elf = "^11 | ^12.2"
+avrada_rts = "^2.0.1"
+avrada_mcu = "^2.0.1"
+
+
+[origin]
+commit = "2625ad6cd549d623511fe94cd2b4a611fe43acbf"
+url = "git+https://github.com/RREE/AVRAda_Lib.git"
+


### PR DESCRIPTION
This crate requires the prior acceptance of avrada_RTS and avrada_mcu. The working examples (avrada_examples) will come next.