### PR TITLE
Add externals for libtcl, libtk.

### DIFF
--- a/index/li/libtcl/libtcl-external.toml
+++ b/index/li/libtcl/libtcl-external.toml
@@ -1,0 +1,15 @@
+description = "Tcl (Tool Control Language)"
+name = "libtcl"
+licenses = "TCL"
+
+authors = ["Simon Wright"]
+maintainers = ["Simon Wright <simon@pushface.org>"]
+maintainers-logins = ["simonjwright"]
+
+[[external]]
+hint = "Please install Tcl from source or sytem packages"
+kind = "system"
+[external.origin."case(distribution)"]
+"debian|ubuntu" = ["tcl8.6-dev"]
+"msys2" = ["mingw-w64-x86_64-tcl"]
+"homebrew" = ["tcl-tk"]

--- a/index/li/libtcl/libtcl-external.toml
+++ b/index/li/libtcl/libtcl-external.toml
@@ -7,7 +7,7 @@ maintainers = ["Simon Wright <simon@pushface.org>"]
 maintainers-logins = ["simonjwright"]
 
 [[external]]
-hint = "Please install Tcl from source or sytem packages"
+hint = "Please install Tcl from source or system packages"
 kind = "system"
 [external.origin."case(distribution)"]
 "debian|ubuntu" = ["tcl8.6-dev"]

--- a/index/li/libtk/libtk-external.toml
+++ b/index/li/libtk/libtk-external.toml
@@ -1,0 +1,15 @@
+description = "Tk (Tool Control Language Toolkit)"
+name = "libtk"
+licenses = "TCL"
+
+authors = ["Simon Wright"]
+maintainers = ["Simon Wright <simon@pushface.org>"]
+maintainers-logins = ["simonjwright"]
+
+[[external]]
+hint = "Please install Tk from source or sytem packages"
+kind="system"
+[external.origin."case(distribution)"]
+"debian|ubuntu" = ["tk8.6-dev"]
+"msys2" = ["mingw-w64-x86_64-tk"]
+"homebrew" = ["tcl-tk"]

--- a/index/li/libtk/libtk-external.toml
+++ b/index/li/libtk/libtk-external.toml
@@ -7,7 +7,7 @@ maintainers = ["Simon Wright <simon@pushface.org>"]
 maintainers-logins = ["simonjwright"]
 
 [[external]]
-hint = "Please install Tk from source or sytem packages"
+hint = "Please install Tk from source or system packages"
 kind="system"
 [external.origin."case(distribution)"]
 "debian|ubuntu" = ["tk8.6-dev"]


### PR DESCRIPTION
macOS note: these call up the Homebrew package tcl-tk, but as usual if the user isn't using alr 1.3 they can install the package themselves.