### PR TITLE
Add PowerJoular

### DIFF
--- a/index/po/powerjoular/powerjoular-0.4.0-dev.toml
+++ b/index/po/powerjoular/powerjoular-0.4.0-dev.toml
@@ -1,0 +1,19 @@
+name = "powerjoular"
+description = "Monitoring the power consumption of multiple platforms and processes"
+version = "0.4.0-dev"
+
+authors = ["Adel Noureddine"]
+maintainers = ["Adel Noureddine <adel.noureddine@univ-pau.fr>"]
+maintainers-logins = ["adelnoureddine"]
+
+licenses = "GPL-3.0-only"
+website = "https://www.noureddine.org/research/joular/powerjoular"
+
+executables = ["powerjoular"]
+[[depends-on]]
+gnatcoll = "^22.0.0"
+
+[origin]
+commit = "23eecb9c2807329f2bb1d104ec198d2d7a95204c"
+url = "git+https://gitlab.com/joular/powerjoular.git"
+


### PR DESCRIPTION
Add PowerJoular, a Linux tool to monitor the power consumption of multiple platforms and processes (x86, ARM RPi, etc.)