### PR TITLE
Add Support for Fedora

### DIFF
--- a/index/li/libpq/libpq-external.toml
+++ b/index/li/libpq/libpq-external.toml
@@ -8,5 +8,5 @@ maintainers-logins = ["reznikmm"]
 kind = "system"
 [external.origin."case(distribution)"]
 "fedora" = ["libqp-devel"]
-"debian|ubuntu" = ["libpq-dev"]
+"debian|ubuntu" = ["libqp-dev"]
 "msys2" = ["mingw-w64-x86_64-postgresql"]

--- a/index/li/libpq/libpq-external.toml
+++ b/index/li/libpq/libpq-external.toml
@@ -7,5 +7,6 @@ maintainers-logins = ["reznikmm"]
 [[external]]
 kind = "system"
 [external.origin."case(distribution)"]
+"fedora" = ["libqp-devel"]
 "debian|ubuntu" = ["libpq-dev"]
 "msys2" = ["mingw-w64-x86_64-postgresql"]

--- a/index/li/libpq/libpq-external.toml
+++ b/index/li/libpq/libpq-external.toml
@@ -7,6 +7,6 @@ maintainers-logins = ["reznikmm"]
 [[external]]
 kind = "system"
 [external.origin."case(distribution)"]
-"fedora" = ["libqp-devel"]
-"debian|ubuntu" = ["libqp-dev"]
+"fedora" = ["libpq-devel"]
+"debian|ubuntu" = ["libpq-dev"]
 "msys2" = ["mingw-w64-x86_64-postgresql"]


### PR DESCRIPTION
Nomenclature of package name is different on Fedora, certainly the case for all RPM based distribution...