### PR TITLE
Add PowerJoular

### DIFF
--- a/index/po/powerjoular/powerjoular-0.4.0.toml
+++ b/index/po/powerjoular/powerjoular-0.4.0.toml
@@ -6,6 +6,8 @@ authors = ["Adel Noureddine"]
 maintainers = ["Adel Noureddine <adel.noureddine@univ-pau.fr>"]
 maintainers-logins = ["adelnoureddine"]
 
+tags = ["linux", "power", "energy"]
+
 licenses = "GPL-3.0-only"
 website = "https://www.noureddine.org/research/joular/powerjoular"
 

--- a/index/po/powerjoular/powerjoular-0.4.0.toml
+++ b/index/po/powerjoular/powerjoular-0.4.0.toml
@@ -1,0 +1,18 @@
+name = "powerjoular"
+description = "Monitoring the power consumption of multiple platforms and processes"
+version = "0.4.0"
+
+authors = ["Adel Noureddine"]
+maintainers = ["Adel Noureddine <adel.noureddine@univ-pau.fr>"]
+maintainers-logins = ["adelnoureddine"]
+
+licenses = "GPL-3.0-only"
+website = "https://www.noureddine.org/research/joular/powerjoular"
+
+executables = ["powerjoular"]
+[[depends-on]]
+gnatcoll = "^22.0.0"
+
+[origin]
+commit = "eff6f15febd9bafd26aee9cee2624b4306e76b10"
+url = "git+https://gitlab.com/joular/powerjoular.git"


### PR DESCRIPTION
Add PowerJoular, a Linux tool to monitor the power consumption of multiple platforms and processes (x86, ARM RPi, etc.)