### PR TITLE
Add dependency on gnat 11 for libadalang_tools

### DIFF
--- a/index/li/libadalang_tools/libadalang_tools-22.0.0.toml
+++ b/index/li/libadalang_tools/libadalang_tools-22.0.0.toml
@@ -18,6 +18,7 @@ hashes = ["sha512:c9028428379e68644dee140b76c6806b15561484bdc77a8c85c88c1ae4de51
 
 [[depends-on]]
 libadalang = "22.0.0"
+gnat = "^11"
 
 [[actions.'case(os)'.windows]]
 type = "post-fetch"


### PR DESCRIPTION
libadalang_tools crate does not build correctly with GNAT 12 because of new diagnostic message.