### PR TITLE
Remove Pins in the Avrada Crates

### DIFF
--- a/index/av/avrada_examples/avrada_examples-1.0.1.toml
+++ b/index/av/avrada_examples/avrada_examples-1.0.1.toml
@@ -1,0 +1,18 @@
+name = "avrada_examples"
+description = "Sample applications in Ada for AVR microcontrollers"
+version = "1.0.1"
+
+authors = ["Rolf Ebert"]
+maintainers = ["Rolf Ebert <rolf.ebert.gcc@gmx.de>"]
+maintainers-logins = ["RREE"]
+licenses = "GPL-2.0-or-later WITH GCC-exception-3.1"
+website = "https://sourceforge.net/projects/avr-ada/"
+tags = ["avr", "embedded", "demo"]
+
+project-files = ["avrada_examples.gpr"]
+
+
+[origin]
+commit = "4a70daba47092abe701c23cfd89197d2afe1c949"
+url = "git+https://github.com/RREE/AVRAda_Examples.git"
+

--- a/index/av/avrada_examples/avrada_examples-1.0.1.toml
+++ b/index/av/avrada_examples/avrada_examples-1.0.1.toml
@@ -13,6 +13,6 @@ project-files = ["avrada_examples.gpr"]
 
 
 [origin]
-commit = "4a70daba47092abe701c23cfd89197d2afe1c949"
+commit = "72780c766d5e3cb674d012c1775015d4442ce6e0"
 url = "git+https://github.com/RREE/AVRAda_Examples.git"
 

--- a/index/av/avrada_lib/avrada_lib-2.0.2.toml
+++ b/index/av/avrada_lib/avrada_lib-2.0.2.toml
@@ -1,0 +1,32 @@
+name = "avrada_lib"
+description = "Library of drivers for AVR microcontrollers"
+version = "2.0.2"
+
+authors = ["Rolf Ebert"]
+maintainers = ["Rolf Ebert <rolf.ebert.gcc@gmx.de>"]
+maintainers-logins = ["RREE"]
+licenses = "GPL-2.0-or-later WITH GCC-exception-3.1"
+website = "https://sourceforge.net/projects/avr-ada/"
+tags = ["avr", "embedded", "drivers"]
+
+[configuration.variables]
+# If your program uses AVR.Real_Time.Timing_Events you can either
+# handle them in your main loop (False) or during the 1ms clock tick
+# of Timer0 (True). Defaults to false as most applications do not use
+# timing events.
+Process_Timing_Events_In_Ticks = {type = "Boolean", default = false}
+
+# Serial/UART receive mode can either be by polling the Rx bit or by
+# interrupt.  Interrupt mode is only partly implemented.
+UART_Receive_Mode = {type = "Enum", values = ["polled", "interrupt"], default = "polled"}
+
+[[depends-on]]
+gnat_avr_elf = "^11 | ^12.2"
+avrada_rts = "^2.0.1"
+avrada_mcu = "^2.0.2"
+
+
+[origin]
+commit = "be6627e45742750d410abcd3da079222ee3ca3b0"
+url = "git+https://github.com/RREE/AVRAda_Lib.git"
+

--- a/index/av/avrada_mcu/avrada_mcu-2.0.2.toml
+++ b/index/av/avrada_mcu/avrada_mcu-2.0.2.toml
@@ -1,0 +1,20 @@
+name = "avrada_mcu"
+description = "Device (MCU) specific definitions for AVR microcontrollers"
+version = "2.0.2"
+
+authors = ["Rolf Ebert"]
+maintainers = ["Rolf Ebert <rolf.ebert.gcc@gmx.de>"]
+maintainers-logins = ["RREE"]
+licenses = "GPL-2.0-or-later WITH GCC-exception-3.1"
+website = "https://sourceforge.net/projects/avr-ada/"
+tags = ["avr", "embedded", "rts"]
+
+[[depends-on]]
+gnat_avr_elf = "^11 | ^12.2"
+avrada_rts = "^2.0.1"
+
+
+[origin]
+commit = "f6ef583f07cd5f1cf70e2b6c43e072df3a69b860"
+url = "git+https://github.com/RREE/AVRAda_MCU.git"
+


### PR DESCRIPTION
The crates of AVRAda_MCU, AVRAda_Lib, and the subdirs of AVRAda_Examples all had still the pins from development. They are removed now.