### PR TITLE
Disable pkg-config-detected externals

### DIFF
--- a/index/li/libgmp/libgmp-external.toml
+++ b/index/li/libgmp/libgmp-external.toml
@@ -15,3 +15,7 @@ msys2 = ["mingw-w64-x86_64-gmp"]
 kind = "version-output"
 version-command = [ "pkg-config", "--modversion", "gmp" ]
 version-regexp = "([\\d\\.]+)"
+
+# pkg-config requires further steps to make packages findable by
+# dependencies that Alire does not yet support
+available = false

--- a/index/li/libgnutls/libgnutls-external.toml
+++ b/index/li/libgnutls/libgnutls-external.toml
@@ -14,3 +14,7 @@ kind = "system"
 kind = "version-output"
 version-command = [ "pkg-config", "--modversion", "gnutls" ]
 version-regexp = "([\\d\\.]+)"
+
+# pkg-config requires further steps to make packages findable by
+# dependencies that Alire does not yet support
+available = false

--- a/index/li/libgtk3/libgtk3-external.toml
+++ b/index/li/libgtk3/libgtk3-external.toml
@@ -16,3 +16,6 @@ msys2 = ["mingw-w64-x86_64-gtk3"]
 kind = "version-output"
 version-command = [ "pkg-config", "--modversion", "gtk+-3.0" ]
 version-regexp = "([\\d\\.]+)"
+# pkg-config requires further steps to make packages findable by
+# dependencies that Alire does not yet support
+available = false


### PR DESCRIPTION
Proper use of these packages would require calling `pkg-config` to set up environment, which Alire does not do (yet?). As is, now Alire thinks they're available but clients don't find them at compilation time.

@simonjwright , @Blady-Com does your understanding of how `pkg-config` works on macOS match my interpretation?

Edit: rather that removing these externals, we keep them unavailable in case we support `pkg-config` in the future.