### PR TITLE
Update URL in Matreshka crates.

### DIFF
--- a/index/ma/matreshka_amf/matreshka_amf-18.1.0.toml
+++ b/index/ma/matreshka_amf/matreshka_amf-18.1.0.toml
@@ -1,7 +1,7 @@
 description = "Implementation of OMG's Meta Object Facility (MOF)"
 name = "matreshka_amf"
 version = "18.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_amf/matreshka_amf-20.1.0.toml
+++ b/index/ma/matreshka_amf/matreshka_amf-20.1.0.toml
@@ -1,7 +1,7 @@
 description = "Implementation of OMG's Meta Object Facility (MOF)"
 name = "matreshka_amf"
 version = "20.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_amf/matreshka_amf-21.0.0.toml
+++ b/index/ma/matreshka_amf/matreshka_amf-21.0.0.toml
@@ -1,7 +1,7 @@
 description = "Implementation of OMG's Meta Object Facility (MOF)"
 name = "matreshka_amf"
 version = "21.0.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_amf_dd/matreshka_amf_dd-18.1.0.toml
+++ b/index/ma/matreshka_amf_dd/matreshka_amf_dd-18.1.0.toml
@@ -1,7 +1,7 @@
 description = "Diagram Definition (DD) specification support for AMF"
 name = "matreshka_amf_dd"
 version = "18.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_amf_dd/matreshka_amf_dd-20.1.0.toml
+++ b/index/ma/matreshka_amf_dd/matreshka_amf_dd-20.1.0.toml
@@ -1,7 +1,7 @@
 description = "Diagram Definition (DD) specification support for AMF"
 name = "matreshka_amf_dd"
 version = "20.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_amf_dd/matreshka_amf_dd-21.0.0.toml
+++ b/index/ma/matreshka_amf_dd/matreshka_amf_dd-21.0.0.toml
@@ -1,7 +1,7 @@
 description = "Diagram Definition (DD) specification support for AMF"
 name = "matreshka_amf_dd"
 version = "21.0.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_amf_mofext/matreshka_amf_mofext-18.1.0.toml
+++ b/index/ma/matreshka_amf_mofext/matreshka_amf_mofext-18.1.0.toml
@@ -1,7 +1,7 @@
 description = "The UML mofext for AMF"
 name = "matreshka_amf_mofext"
 version = "18.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_amf_mofext/matreshka_amf_mofext-20.1.0.toml
+++ b/index/ma/matreshka_amf_mofext/matreshka_amf_mofext-20.1.0.toml
@@ -1,7 +1,7 @@
 description = "The UML mofext for AMF"
 name = "matreshka_amf_mofext"
 version = "20.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_amf_mofext/matreshka_amf_mofext-21.0.0.toml
+++ b/index/ma/matreshka_amf_mofext/matreshka_amf_mofext-21.0.0.toml
@@ -1,7 +1,7 @@
 description = "The UML mofext for AMF"
 name = "matreshka_amf_mofext"
 version = "21.0.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_amf_ocl/matreshka_amf_ocl-18.1.0.toml
+++ b/index/ma/matreshka_amf_ocl/matreshka_amf_ocl-18.1.0.toml
@@ -1,7 +1,7 @@
 description = "The UML OCL for AMF"
 name = "matreshka_amf_ocl"
 version = "18.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_amf_ocl/matreshka_amf_ocl-20.1.0.toml
+++ b/index/ma/matreshka_amf_ocl/matreshka_amf_ocl-20.1.0.toml
@@ -1,7 +1,7 @@
 description = "The UML OCL for AMF"
 name = "matreshka_amf_ocl"
 version = "20.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_amf_ocl/matreshka_amf_ocl-21.0.0.toml
+++ b/index/ma/matreshka_amf_ocl/matreshka_amf_ocl-21.0.0.toml
@@ -1,7 +1,7 @@
 description = "The UML OCL for AMF"
 name = "matreshka_amf_ocl"
 version = "21.0.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_amf_uml/matreshka_amf_uml-18.1.0.toml
+++ b/index/ma/matreshka_amf_uml/matreshka_amf_uml-18.1.0.toml
@@ -1,7 +1,7 @@
 description = "Unified Modeling Language support for AMF"
 name = "matreshka_amf_uml"
 version = "18.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_amf_uml/matreshka_amf_uml-20.1.0.toml
+++ b/index/ma/matreshka_amf_uml/matreshka_amf_uml-20.1.0.toml
@@ -1,7 +1,7 @@
 description = "Unified Modeling Language support for AMF"
 name = "matreshka_amf_uml"
 version = "20.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_amf_uml/matreshka_amf_uml-21.0.0.toml
+++ b/index/ma/matreshka_amf_uml/matreshka_amf_uml-21.0.0.toml
@@ -1,7 +1,7 @@
 description = "Unified Modeling Language support for AMF"
 name = "matreshka_amf_uml"
 version = "21.0.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_amf_utp/matreshka_amf_utp-18.1.0.toml
+++ b/index/ma/matreshka_amf_utp/matreshka_amf_utp-18.1.0.toml
@@ -1,7 +1,7 @@
 description = "The UML Testing Profile for AMF"
 name = "matreshka_amf_utp"
 version = "18.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_amf_utp/matreshka_amf_utp-20.1.0.toml
+++ b/index/ma/matreshka_amf_utp/matreshka_amf_utp-20.1.0.toml
@@ -1,7 +1,7 @@
 description = "The UML Testing Profile for AMF"
 name = "matreshka_amf_utp"
 version = "20.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_amf_utp/matreshka_amf_utp-21.0.0.toml
+++ b/index/ma/matreshka_amf_utp/matreshka_amf_utp-21.0.0.toml
@@ -1,7 +1,7 @@
 description = "The UML Testing Profile for AMF"
 name = "matreshka_amf_utp"
 version = "21.0.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_fastcgi/matreshka_fastcgi-18.1.0.toml
+++ b/index/ma/matreshka_fastcgi/matreshka_fastcgi-18.1.0.toml
@@ -1,7 +1,7 @@
 description = "FastCGI implementation (demo)"
 name = "matreshka_fastcgi"
 version = "18.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_fastcgi/matreshka_fastcgi-20.1.0.toml
+++ b/index/ma/matreshka_fastcgi/matreshka_fastcgi-20.1.0.toml
@@ -1,7 +1,7 @@
 description = "FastCGI implementation (demo)"
 name = "matreshka_fastcgi"
 version = "20.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_fastcgi/matreshka_fastcgi-21.0.0.toml
+++ b/index/ma/matreshka_fastcgi/matreshka_fastcgi-21.0.0.toml
@@ -1,7 +1,7 @@
 description = "FastCGI implementation (demo)"
 name = "matreshka_fastcgi"
 version = "21.0.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_league/matreshka_league-18.1.0.toml
+++ b/index/ma/matreshka_league/matreshka_league-18.1.0.toml
@@ -1,7 +1,7 @@
 description = "League - universal string library. Part of Matreshka framework"
 name = "matreshka_league"
 version = "18.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]
@@ -17,6 +17,6 @@ command = ["make", "reconfig"]
 make = "any"
 
 [origin]
-url = "http://forge.ada-ru.org/matreshka/downloads/matreshka-18.1.tar.gz"
+url = "https://github.com/godunko/matreshka/releases/download/18.1/matreshka-18.1.tar.gz"
 archive-name = "matreshka-18.1.tar.gz"
 hashes = ["sha512:4fab6c039550017f6cd16d6216f76e9651f1fd5c24d842cccd5ca1340733216ff5dca4aea8babd6c43da8bb75db94681b398f3c04c2a7e4cca7ae49a7c56aa76"]

--- a/index/ma/matreshka_league/matreshka_league-20.1.0.toml
+++ b/index/ma/matreshka_league/matreshka_league-20.1.0.toml
@@ -1,7 +1,7 @@
 description = "League - universal string library. Part of Matreshka framework"
 name = "matreshka_league"
 version = "20.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]
@@ -27,6 +27,6 @@ gnat = "<11"
 gnat = "<11|(>=2000 & <2021)"
 
 [origin]
-url = "http://forge.ada-ru.org/matreshka/downloads/matreshka-20.1.tar.gz"
+url = "https://github.com/godunko/matreshka/releases/download/20.1/matreshka-20.1.tar.gz"
 archive-name = "matreshka-20.1.tar.gz"
 hashes = ["sha512:41ddb44a6073cb57c88e25024f6e2db94003e98263ef38feecb752021d6e9213c12303efc2557e1842100aa4f52d3b58323319dcc1394fe21d3514258c19e466"]

--- a/index/ma/matreshka_league/matreshka_league-21.0.0.toml
+++ b/index/ma/matreshka_league/matreshka_league-21.0.0.toml
@@ -1,7 +1,7 @@
 description = "League - universal string library. Part of Matreshka framework"
 name = "matreshka_league"
 version = "21.0.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]
@@ -21,6 +21,6 @@ gnat = "<2000"
 # GNAT CE 2020 miss TLS support, alire GCC 11 works fine
 
 [origin]
-url = "http://forge.ada-ru.org/matreshka/downloads/matreshka-21.0.tar.gz"
+url = "https://github.com/godunko/matreshka/releases/download/21.0/matreshka-21.0.tar.gz"
 archive-name = "matreshka-21.0.tar.gz"
 hashes = ["sha512:0c8f4d478d64e761967b3bcb7aae56fe08c4dd254acfe17a704cf21d2ba9f4b8faed470268c8c6dfa2b6e0dcab64e5fdaae04361657b8d5fa85dd35e6a76e9b2"]

--- a/index/ma/matreshka_servlet/matreshka_servlet-18.1.0.toml
+++ b/index/ma/matreshka_servlet/matreshka_servlet-18.1.0.toml
@@ -1,7 +1,7 @@
 description = "Servlet API"
 name = "matreshka_servlet"
 version = "18.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_servlet/matreshka_servlet-20.1.0.toml
+++ b/index/ma/matreshka_servlet/matreshka_servlet-20.1.0.toml
@@ -1,7 +1,7 @@
 description = "Servlet API"
 name = "matreshka_servlet"
 version = "20.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_servlet/matreshka_servlet-21.0.0.toml
+++ b/index/ma/matreshka_servlet/matreshka_servlet-21.0.0.toml
@@ -1,7 +1,7 @@
 description = "Servlet API"
 name = "matreshka_servlet"
 version = "21.0.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_soap/matreshka_soap-18.1.0.toml
+++ b/index/ma/matreshka_soap/matreshka_soap-18.1.0.toml
@@ -1,7 +1,7 @@
 description = "Framework for work with SOAP 1.2"
 name = "matreshka_soap"
 version = "18.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_soap/matreshka_soap-20.1.0.toml
+++ b/index/ma/matreshka_soap/matreshka_soap-20.1.0.toml
@@ -1,7 +1,7 @@
 description = "Framework for work with SOAP 1.2"
 name = "matreshka_soap"
 version = "20.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_soap/matreshka_soap-21.0.0.toml
+++ b/index/ma/matreshka_soap/matreshka_soap-21.0.0.toml
@@ -1,7 +1,7 @@
 description = "Framework for work with SOAP 1.2"
 name = "matreshka_soap"
 version = "21.0.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_soap_wsse/matreshka_soap_wsse-18.1.0.toml
+++ b/index/ma/matreshka_soap_wsse/matreshka_soap_wsse-18.1.0.toml
@@ -1,7 +1,7 @@
 description = "WS-Security 1.1 implementation for SOAP 1.2"
 name = "matreshka_soap_wsse"
 version = "18.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_soap_wsse/matreshka_soap_wsse-20.1.0.toml
+++ b/index/ma/matreshka_soap_wsse/matreshka_soap_wsse-20.1.0.toml
@@ -1,7 +1,7 @@
 description = "WS-Security 1.1 implementation for SOAP 1.2"
 name = "matreshka_soap_wsse"
 version = "20.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_soap_wsse/matreshka_soap_wsse-21.0.0.toml
+++ b/index/ma/matreshka_soap_wsse/matreshka_soap_wsse-21.0.0.toml
@@ -1,7 +1,7 @@
 description = "WS-Security 1.1 implementation for SOAP 1.2"
 name = "matreshka_soap_wsse"
 version = "21.0.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_spikedog_api/matreshka_spikedog_api-18.1.0.toml
+++ b/index/ma/matreshka_spikedog_api/matreshka_spikedog_api-18.1.0.toml
@@ -1,7 +1,7 @@
 description = "Web-application server. API library"
 name = "matreshka_spikedog_api"
 version = "18.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_spikedog_api/matreshka_spikedog_api-20.1.0.toml
+++ b/index/ma/matreshka_spikedog_api/matreshka_spikedog_api-20.1.0.toml
@@ -1,7 +1,7 @@
 description = "Web-application server. API library"
 name = "matreshka_spikedog_api"
 version = "20.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_spikedog_api/matreshka_spikedog_api-21.0.0.toml
+++ b/index/ma/matreshka_spikedog_api/matreshka_spikedog_api-21.0.0.toml
@@ -1,7 +1,7 @@
 description = "Web-application server. API library"
 name = "matreshka_spikedog_api"
 version = "21.0.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_spikedog_awsd/matreshka_spikedog_awsd-18.1.0.toml
+++ b/index/ma/matreshka_spikedog_awsd/matreshka_spikedog_awsd-18.1.0.toml
@@ -1,7 +1,7 @@
 description = "Web-application server. API library"
 name = "matreshka_spikedog_awsd"
 version = "18.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 executables = ["spikedog_awsd"]
 licenses = "BSD-3-Clause"

--- a/index/ma/matreshka_spikedog_awsd/matreshka_spikedog_awsd-20.1.0.toml
+++ b/index/ma/matreshka_spikedog_awsd/matreshka_spikedog_awsd-20.1.0.toml
@@ -1,7 +1,7 @@
 description = "Web-application server. API library"
 name = "matreshka_spikedog_awsd"
 version = "20.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 executables = ["spikedog_awsd"]
 licenses = "BSD-3-Clause"

--- a/index/ma/matreshka_spikedog_awsd/matreshka_spikedog_awsd-21.0.0.toml
+++ b/index/ma/matreshka_spikedog_awsd/matreshka_spikedog_awsd-21.0.0.toml
@@ -1,7 +1,7 @@
 description = "Web-application server. API library"
 name = "matreshka_spikedog_awsd"
 version = "21.0.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 executables = ["spikedog_awsd"]
 licenses = "BSD-3-Clause"

--- a/index/ma/matreshka_spikedog_core/matreshka_spikedog_core-18.1.0.toml
+++ b/index/ma/matreshka_spikedog_core/matreshka_spikedog_core-18.1.0.toml
@@ -1,7 +1,7 @@
 description = "Web-application server. Implementation library"
 name = "matreshka_spikedog_core"
 version = "18.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_spikedog_core/matreshka_spikedog_core-20.1.0.toml
+++ b/index/ma/matreshka_spikedog_core/matreshka_spikedog_core-20.1.0.toml
@@ -1,7 +1,7 @@
 description = "Web-application server. Implementation library"
 name = "matreshka_spikedog_core"
 version = "20.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_spikedog_core/matreshka_spikedog_core-21.0.0.toml
+++ b/index/ma/matreshka_spikedog_core/matreshka_spikedog_core-21.0.0.toml
@@ -1,7 +1,7 @@
 description = "Web-application server. Implementation library"
 name = "matreshka_spikedog_core"
 version = "21.0.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_sql/matreshka_sql-18.1.0.toml
+++ b/index/ma/matreshka_sql/matreshka_sql-18.1.0.toml
@@ -1,7 +1,7 @@
 description = "Common SQL Database API"
 name = "matreshka_sql"
 version = "18.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_sql/matreshka_sql-20.1.0.toml
+++ b/index/ma/matreshka_sql/matreshka_sql-20.1.0.toml
@@ -1,7 +1,7 @@
 description = "Common SQL Database API"
 name = "matreshka_sql"
 version = "20.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_sql/matreshka_sql-21.0.0.toml
+++ b/index/ma/matreshka_sql/matreshka_sql-21.0.0.toml
@@ -1,7 +1,7 @@
 description = "Common SQL Database API"
 name = "matreshka_sql"
 version = "21.0.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_sql_firebird/matreshka_sql_firebird-20.1.0.toml
+++ b/index/ma/matreshka_sql_firebird/matreshka_sql_firebird-20.1.0.toml
@@ -1,7 +1,7 @@
 description = "Firebird SQL binding for Ada"
 name = "matreshka_sql_firebird"
 version = "20.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_sql_firebird/matreshka_sql_firebird-21.0.0.toml
+++ b/index/ma/matreshka_sql_firebird/matreshka_sql_firebird-21.0.0.toml
@@ -1,7 +1,7 @@
 description = "Firebird SQL binding for Ada"
 name = "matreshka_sql_firebird"
 version = "21.0.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_sql_mysql/matreshka_sql_mysql-20.1.0.toml
+++ b/index/ma/matreshka_sql_mysql/matreshka_sql_mysql-20.1.0.toml
@@ -1,7 +1,7 @@
 description = "MySQL binding for Ada"
 name = "matreshka_sql_mysql"
 version = "20.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_sql_mysql/matreshka_sql_mysql-21.0.0.toml
+++ b/index/ma/matreshka_sql_mysql/matreshka_sql_mysql-21.0.0.toml
@@ -1,7 +1,7 @@
 description = "MySQL binding for Ada"
 name = "matreshka_sql_mysql"
 version = "21.0.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_sql_oracle/matreshka_sql_oracle-20.1.0.toml
+++ b/index/ma/matreshka_sql_oracle/matreshka_sql_oracle-20.1.0.toml
@@ -1,7 +1,7 @@
 description = "Oracle DB binding for Ada"
 name = "matreshka_sql_oracle"
 version = "20.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_sql_oracle/matreshka_sql_oracle-21.0.0.toml
+++ b/index/ma/matreshka_sql_oracle/matreshka_sql_oracle-21.0.0.toml
@@ -1,7 +1,7 @@
 description = "Oracle DB binding for Ada"
 name = "matreshka_sql_oracle"
 version = "21.0.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_sql_postgresql/matreshka_sql_postgresql-20.1.0.toml
+++ b/index/ma/matreshka_sql_postgresql/matreshka_sql_postgresql-20.1.0.toml
@@ -1,7 +1,7 @@
 description = "PostgreSQL binding for Ada"
 name = "matreshka_sql_postgresql"
 version = "20.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_sql_postgresql/matreshka_sql_postgresql-21.0.0.toml
+++ b/index/ma/matreshka_sql_postgresql/matreshka_sql_postgresql-21.0.0.toml
@@ -1,7 +1,7 @@
 description = "PostgreSQL binding for Ada"
 name = "matreshka_sql_postgresql"
 version = "21.0.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_sql_sqlite3/matreshka_sql_sqlite3-20.1.0.toml
+++ b/index/ma/matreshka_sql_sqlite3/matreshka_sql_sqlite3-20.1.0.toml
@@ -1,7 +1,7 @@
 description = "SQLite binding for Ada"
 name = "matreshka_sql_sqlite3"
 version = "20.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_sql_sqlite3/matreshka_sql_sqlite3-21.0.0.toml
+++ b/index/ma/matreshka_sql_sqlite3/matreshka_sql_sqlite3-21.0.0.toml
@@ -1,7 +1,7 @@
 description = "SQLite binding for Ada"
 name = "matreshka_sql_sqlite3"
 version = "21.0.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_xml/matreshka_xml-18.1.0.toml
+++ b/index/ma/matreshka_xml/matreshka_xml-18.1.0.toml
@@ -1,7 +1,7 @@
 description = "Library to manipulate with XML streams and documents"
 name = "matreshka_xml"
 version = "18.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_xml/matreshka_xml-20.1.0.toml
+++ b/index/ma/matreshka_xml/matreshka_xml-20.1.0.toml
@@ -1,7 +1,7 @@
 description = "Library to manipulate with XML streams and documents"
 name = "matreshka_xml"
 version = "20.1.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]

--- a/index/ma/matreshka_xml/matreshka_xml-21.0.0.toml
+++ b/index/ma/matreshka_xml/matreshka_xml-21.0.0.toml
@@ -1,7 +1,7 @@
 description = "Library to manipulate with XML streams and documents"
 name = "matreshka_xml"
 version = "21.0.0"
-website = "https://forge.ada-ru.org/matreshka"
+website = "https://github.com/godunko/matreshka"
 authors = ["Vadim Godunko"]
 licenses = "BSD-3-Clause"
 maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>"]


### PR DESCRIPTION
The site https://forge.ada-ru.org isn't available any more, so replace source archives with GitHub release URLs.