### PR TITLE
Adabots 1.3.0: fix AWS dependency

### DIFF
--- a/index/ad/adabots/adabots-1.3.0.toml
+++ b/index/ad/adabots/adabots-1.3.0.toml
@@ -1,0 +1,22 @@
+name = "adabots"
+description = "Learn Ada by programming Minecraft robots"
+version = "1.3.0"
+
+authors = ["Tama McGlinn"]
+maintainers = ["Tama McGlinn <t.mcglinn@gmail.com>"]
+maintainers-logins = ["TamaMcGlinn"]
+
+licenses = "MIT"
+project-files = ["adabots.gpr"]
+tags = ["learn", "ada", "minecraft", "computercraft", "robots", "teach", "children"]
+
+[[depends-on]]  # This line was added by `alr with`
+aws = "^23.0.0"  # This line was added by `alr with`
+
+[[depends-on]]  # This line was added by `alr with`
+aaa = "~0.2.3"  # This line was added by `alr with`
+
+[origin]
+commit = "944adbafc42efda42580914c0e6401c8ca75612c"
+url = "git+https://github.com/TamaMcGlinn/AdaBots.git"
+


### PR DESCRIPTION
New Adabots 1.3.0 release: Switched AWS to version 23.0 to fix an error relating to relocatable symbols before, details here: https://github.com/AdaCore/aws/issues/356