### PR TITLE
remoteio release 1.20650.1

### DIFF
--- a/index/re/remoteio/remoteio-1.20650.1.toml
+++ b/index/re/remoteio/remoteio-1.20650.1.toml
@@ -1,0 +1,48 @@
+name = "remoteio"
+description = "Remote I/O Protocol Client Library for GNAT Ada"
+version = "1.20650.1"
+licenses = "BSD-1-Clause"
+website = "https://github.com/pmunts/libsimpleio"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["remoteio.gpr"]
+
+tags = ["embedded", "linux", "remoteio", "adc", "dac", "gpio", "i2c", "motor",
+"pwm", "sensor", "serial", "servo", "spi", "stepper"]
+
+[available."case(os)"]
+'linux|windows' = true
+"..." = false
+
+# Linux needs libhidapi-dev and/or libusb-1.0-0-dev installed
+
+[[depends-on]]
+[depends-on."case(os)"."linux"]
+libhidapi = "*"
+
+[[depends-on]]
+[depends-on."case(os)"."linux"]
+libusb = "~1.0"
+
+# On Linux, patch hid-hidapi.ads to link with libhidapi-hidraw.so
+
+[[actions."case(os)".linux]]
+type = "post-fetch"
+command = ["sh", "-c", "sed -i 's/lhidapi/lhidapi-hidraw/g' src/objects/hid-hidapi.ads"]
+
+# On Windows, copy .DLL files to ./bin/ (for execution) and ./lib/ (for linking)
+
+[[actions."case(os)".windows]]
+type = "post-fetch"
+command = ["sh", "-c", "mkdir -p ./bin && cp src/win64/*.dll ./bin && mkdir -p ./lib && cp src/win64/*.dll ./lib"]
+
+[origin]
+hashes = [
+"sha256:c3991b8f917416ce85f47f067f33892fec9d0da8b97ba4190ef842e72bac4f68",
+"sha512:94eec7f644e8a0fc57bec7044db9571b2fa7d2c71ad19dfcf74a88419e7e430e2833b998851eb54a09637ffecd44df30abea775cb4bff8ea21d82a44a8a22e93",
+]
+url = "http://repo.munts.com/alire/remoteio-1.20650.1.tbz2"
+


### PR DESCRIPTION
Fixed or suppressed many (but not all) compiler warnings.

Made major improvement to Mikroelektronika Click board support, especially for BeagleBone target platforms.