### PR TITLE
new version 2.2 of avrada_mcu 

### DIFF
--- a/index/av/avrada_mcu/avrada_mcu-2.2.0.toml
+++ b/index/av/avrada_mcu/avrada_mcu-2.2.0.toml
@@ -1,0 +1,20 @@
+name = "avrada_mcu"
+description = "Device (MCU) specific definitions for AVR microcontrollers"
+version = "2.2.0"
+
+authors = ["Rolf Ebert"]
+maintainers = ["Rolf Ebert <rolf.ebert.gcc@gmx.de>"]
+maintainers-logins = ["RREE"]
+licenses = "GPL-2.0-or-later WITH GCC-exception-3.1"
+website = "https://sourceforge.net/projects/avr-ada/"
+tags = ["avr", "embedded", "rts"]
+
+[[depends-on]]
+gnat_avr_elf = "^11 | ^12.2"
+avrada_rts = "^2.0.1"
+
+
+[origin]
+commit = "b6f5cf0d6b9e4981ce79c6ed7f3dd28600c08dbf"
+url = "git+https://github.com/RREE/AVRAda_MCU.git"
+


### PR DESCRIPTION
fixing missing avr-mcu renamings (https://github.com/RREE/AVRAda_MCU/issues/1)