### PR TITLE
MuntsOS Embedded Linux support crates

### DIFF
--- a/index/mu/muntsos_beaglebone/muntsos_beaglebone-1.0.0.toml
+++ b/index/mu/muntsos_beaglebone/muntsos_beaglebone-1.0.0.toml
@@ -1,0 +1,33 @@
+name = "muntsos_beaglebone"
+description = "MuntsOS Embedded Linux support for BeagleBone targets"
+tags = ["muntsos", "embedded", "linux", "arm", "beaglebone"]
+version = "1.0.0"
+website = "https://github.com/pmunts/muntsos"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["aws.gpr", "libsimpleio.gpr"]
+
+[available."case(os)"]
+"linux" = true
+"..." = false
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+muntsos_dev_beaglebone = "*"
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch"]
+
+[origin]
+hashes = [
+"sha256:64e2009c383d63cd85383e8f435c9a5c44ef4f7a48dfbb87698798db75f605d1",
+"sha512:6ad6de32f56c8fbe72c3d2b5e17b830f6c18f264f8d438e8714b1886e4448b20ae0df3d635308af7d0f3264daa5ff6aad1af490b01bc665c04c5676f06a5c03c",
+]
+url = "http://repo.munts.com/alire/muntsos_beaglebone-1.0.0.tbz2"
+

--- a/index/mu/muntsos_dev_aarch64/muntsos_dev_aarch64-external.toml
+++ b/index/mu/muntsos_dev_aarch64/muntsos_dev_aarch64-external.toml
@@ -1,0 +1,13 @@
+name = "muntsos_dev_aarch64"
+description = "MuntsOS Embedded Linux AArch64 cross-toolchain metapackage"
+tags = ["muntsos", "embedded", "linux", "aarch64", "arm64"]
+website = "https://github.com/pmunts/muntsos"
+
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+[[external]]
+kind = "system"
+hint = "Install from the Munts Technologies Debian Package Repository at http://repo.munts.com/debian11"
+[external.origin."case(distribution)"]
+"debian" = ["muntsos-dev-aarch64"]

--- a/index/mu/muntsos_dev_beaglebone/muntsos_dev_beaglebone-external.toml
+++ b/index/mu/muntsos_dev_beaglebone/muntsos_dev_beaglebone-external.toml
@@ -1,0 +1,13 @@
+name = "muntsos_dev_beaglebone"
+description = "MuntsOS Embedded Linux BeagleBone ARMv7 cross-toolchain metapackage"
+tags = ["muntsos", "embedded", "linux", "arm", "beaglebone"]
+website = "https://github.com/pmunts/muntsos"
+
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+[[external]]
+kind = "system"
+hint = "Install from the Munts Technologies Debian Package Repository at http://repo.munts.com/debian11"
+[external.origin."case(distribution)"]
+"debian" = ["muntsos-dev-beaglebone"]

--- a/index/mu/muntsos_dev_raspberrypi1/muntsos_dev_raspberrypi1-external.toml
+++ b/index/mu/muntsos_dev_raspberrypi1/muntsos_dev_raspberrypi1-external.toml
@@ -1,0 +1,13 @@
+name = "muntsos_dev_raspberrypi1"
+description = "MuntsOS Embedded Linux RaspberryPi1 ARMv6 cross-toolchain metapackage"
+tags = ["muntsos", "embedded", "linux", "arm", "raspberrypi1"]
+website = "https://github.com/pmunts/muntsos"
+
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+[[external]]
+kind = "system"
+hint = "Install from the Munts Technologies Debian Package Repository at http://repo.munts.com/debian11"
+[external.origin."case(distribution)"]
+"debian" = ["muntsos-dev-raspberrypi1"]

--- a/index/mu/muntsos_dev_raspberrypi2/muntsos_dev_raspberrypi2-external.toml
+++ b/index/mu/muntsos_dev_raspberrypi2/muntsos_dev_raspberrypi2-external.toml
@@ -1,0 +1,13 @@
+name = "muntsos_dev_raspberrypi2"
+description = "MuntsOS Embedded Linux RaspberryPi2 ARMv7 cross-toolchain metapackage"
+tags = ["muntsos", "embedded", "linux", "arm", "raspberrypi2"]
+website = "https://github.com/pmunts/muntsos"
+
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+[[external]]
+kind = "system"
+hint = "Install from the Munts Technologies Debian Package Repository at http://repo.munts.com/debian11"
+[external.origin."case(distribution)"]
+"debian" = ["muntsos-dev-raspberrypi2"]

--- a/index/mu/muntsos_raspberrypi1/muntsos_raspberrypi1-1.0.0.toml
+++ b/index/mu/muntsos_raspberrypi1/muntsos_raspberrypi1-1.0.0.toml
@@ -1,0 +1,33 @@
+name = "muntsos_raspberrypi1"
+description = "MuntsOS Embedded Linux support for RaspberryPi1 targets"
+tags = ["muntsos", "embedded", "linux", "arm", "raspberrypi1"]
+version = "1.0.0"
+website = "https://github.com/pmunts/muntsos"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["aws.gpr", "libsimpleio.gpr"]
+
+[available."case(os)"]
+"linux" = true
+"..." = false
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+muntsos_dev_raspberrypi1 = "*"
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch"]
+
+[origin]
+hashes = [
+"sha256:7cc1995655ebb4e1d01f8f9964eb1846b4b604fbdea3eac243da44913927ab17",
+"sha512:899850e3a83b34a6f8d71bb72f26eff4b0efa4df8f6897328af60cf9700726e0ac6722988030efb357515b7ce486abc1704ff71c87efa9d627fe4b3f4daa8739",
+]
+url = "http://repo.munts.com/alire/muntsos_raspberrypi1-1.0.0.tbz2"
+

--- a/index/mu/muntsos_raspberrypi2/muntsos_raspberrypi2-1.0.0.toml
+++ b/index/mu/muntsos_raspberrypi2/muntsos_raspberrypi2-1.0.0.toml
@@ -1,0 +1,33 @@
+name = "muntsos_raspberrypi2"
+description = "MuntsOS Embedded Linux support for RaspberryPi2 targets"
+tags = ["muntsos", "embedded", "linux", "arm", "raspberrypi2"]
+version = "1.0.0"
+website = "https://github.com/pmunts/muntsos"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["aws.gpr", "libsimpleio.gpr"]
+
+[available."case(os)"]
+"linux" = true
+"..." = false
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+muntsos_dev_raspberrypi2 = "*"
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch"]
+
+[origin]
+hashes = [
+"sha256:95b62b2b35dfdee2f60cd97dec636b56bcfeab950eb0f41c449a8ce032769682",
+"sha512:802d605a9a0dfc887e3f69b25b9b3838c6b2fd2aa69433467ca333dfd1ac24eca233fd55277023b1bde00444c9364c4e4f45150f73adb85e2a94353bfba5f9c6",
+]
+url = "http://repo.munts.com/alire/muntsos_raspberrypi2-1.0.0.tbz2"
+

--- a/index/mu/muntsos_raspberrypi3/muntsos_raspberrypi3-1.0.0.toml
+++ b/index/mu/muntsos_raspberrypi3/muntsos_raspberrypi3-1.0.0.toml
@@ -1,0 +1,33 @@
+name = "muntsos_raspberrypi3"
+description = "MuntsOS Embedded Linux support for RaspberryPi3 targets"
+tags = ["muntsos", "embedded", "linux", "arm64", "raspberrypi3"]
+version = "1.0.0"
+website = "https://github.com/pmunts/muntsos"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["aws.gpr", "libsimpleio.gpr"]
+
+[available."case(os)"]
+"linux" = true
+"..." = false
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+muntsos_dev_aarch64 = "*"
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch"]
+
+[origin]
+hashes = [
+"sha256:9eaf8ca4119ab757ea7e6cad1a266d4f6cc67e85e5d6fe727cbe7c8eea2e68e6",
+"sha512:6f6e47179ce3a3d78b3a147eab2ccdace311c826c4989dfd18bef65983da388d425e754e5e65c634e1d79e60d058c000b9c4b44daaf9ecbdf9a0faba3664b96f",
+]
+url = "http://repo.munts.com/alire/muntsos_raspberrypi3-1.0.0.tbz2"
+

--- a/index/mu/muntsos_raspberrypi4/muntsos_raspberrypi4-1.0.0.toml
+++ b/index/mu/muntsos_raspberrypi4/muntsos_raspberrypi4-1.0.0.toml
@@ -1,0 +1,33 @@
+name = "muntsos_raspberrypi4"
+description = "MuntsOS Embedded Linux support for RaspberryPi4 targets"
+tags = ["muntsos", "embedded", "linux", "arm64", "raspberrypi4"]
+version = "1.0.0"
+website = "https://github.com/pmunts/muntsos"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["aws.gpr", "libsimpleio.gpr"]
+
+[available."case(os)"]
+"linux" = true
+"..." = false
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+muntsos_dev_aarch64 = "*"
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch"]
+
+[origin]
+hashes = [
+"sha256:be34244f4b1500fb470fda1330526269c3d5e8acc9389fe542e4ac69638e6af5",
+"sha512:5da3bc5a4559f1b72faf7bf189228ca33380e12358f9ea34c28eaaf427800362b58d30b2c0f3bf11c61b24f9184b7da7266bed91f63b5bc72546744fb585bd7a",
+]
+url = "http://repo.munts.com/alire/muntsos_raspberrypi4-1.0.0.tbz2"
+


### PR DESCRIPTION
These crates make it as easy as possible to target a Linux microcomputer board running MuntsOS Embedded Linux, by just running something like `alr with muntsos_beaglebone` in the Alire program project directory.

I know these crates will fail the build tests.  Please merge them anyway.  I want to use them for Ada programming tutorial classes, including (hopefully) at Lisbon in June.  These crates hide most of the complexity of using Alire for embedded Linux targets.