### PR TITLE
Initial Alire release of Keypadder crate.

### DIFF
--- a/index/ke/keypadder/keypadder-0.2.0.toml
+++ b/index/ke/keypadder/keypadder-0.2.0.toml
@@ -1,0 +1,43 @@
+name = "keypadder"
+description = "Programmable virtual keypad for your Linux desktop"
+long-description = """
+# Overview
+
+Keypadder runs on your desktop machine and provides a mobile/tablet-friendly
+web page that you use from a tablet or phone to send frequently-used, awkward,
+or difficult-to-remember key combinations to the currently-focused desktop application.
+
+Amongst other things, the author uses it with Thunderbird and LibreOffice Writer 
+for typing accented characters, with MuseScore to provide a keypad similar to a 
+certain commercial score writing application, and with Firefox for accented 
+characters and Emojis in social media.
+
+It's a great use for one of those old smartphones or tablets you have lying in that drawer!
+"""
+version = "0.2.0"
+tags = ["linux", "keyboard", "mobile", "programmable", "tablet", "macro", "keypad", "macropad"]
+
+authors = ["Stephen Merrony"]
+maintainers = ["Stephen Merrony <merrony@gmail.com>"]
+maintainers-logins = ["SMerrony"]
+
+licenses = "GPL-3.0-or-later"
+website = "https://github.com/SMerrony/keypadder"
+
+executables = ["keypadder"]
+
+[available.'case(os)']
+linux   = true
+macos   = false
+windows = false
+'...'   = false
+
+[[depends-on]]
+aws = "^23.0.0"
+[[depends-on]]
+ada_toml = "~0.3.0"
+
+[origin]
+commit = "67bd0bf2547a3110d7de01cf4bb382b761410d5e"
+url = "git+https://github.com/SMerrony/keypadder.git"
+


### PR DESCRIPTION
Keypadder runs on your desktop machine and provides a mobile/tablet-friendly web page that you use from a tablet or phone to send frequently-used, awkward, or difficult-to-remember key combinations to the currently-focused desktop application.