### PR TITLE
Autoclose stale PRs

### DIFF
--- a/.github/workflows/cleaner.yml
+++ b/.github/workflows/cleaner.yml
@@ -1,5 +1,6 @@
 name: 'Close stale PRs'
 on:
+  workflow_dispatch:
   schedule:
     - cron: '11 1 * * *'
 
@@ -11,6 +12,7 @@ jobs:
     steps:
       - uses: actions/stale@v7
         with:
+          debug-only : true # To be removed after checking what it wants to do on our current PRs
           stale-pr-message: 'This PR is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 30 days.'
           close-pr-message: 'This issue was closed because it has been stalled for 90 days with no activity.'
           days-before-stale: 60

--- a/.github/workflows/cleaner.yml
+++ b/.github/workflows/cleaner.yml
@@ -1,0 +1,17 @@
+name: 'Close stale PRs'
+on:
+  schedule:
+    - cron: '11 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v7
+        with:
+          stale-pr-message: 'This PR is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 30 days.'
+          close-pr-message: 'This issue was closed because it has been stalled for 90 days with no activity.'
+          days-before-stale: 60
+          days-before-close: 30


### PR DESCRIPTION
People can comment, push updates to prevent closure, or reopen as needed.

Tested here: https://github.com/mosteo/alire-index/actions/runs/4415253126/jobs/7737981581

Still, here is in dry-run mode as it can only be run from the default branch.