### PR TITLE
Fedora now supported

### DIFF
--- a/index/mu/muntsos_dev_aarch64/muntsos_dev_aarch64-external.toml
+++ b/index/mu/muntsos_dev_aarch64/muntsos_dev_aarch64-external.toml
@@ -8,6 +8,6 @@ maintainers-logins = ["pmunts"]
 
 [[external]]
 kind = "system"
-hint = "Install from the Munts Technologies Debian Package Repository at http://repo.munts.com/debian11"
+hint = "Available at http://repo.munts.com/debian11 or http://repo.munts.com/muntsos/rpms"
 [external.origin."case(distribution)"]
-"debian" = ["muntsos-dev-aarch64"]
+"debian|fedora|ubuntu" = ["muntsos-dev-aarch64"]

--- a/index/mu/muntsos_dev_beaglebone/muntsos_dev_beaglebone-external.toml
+++ b/index/mu/muntsos_dev_beaglebone/muntsos_dev_beaglebone-external.toml
@@ -8,6 +8,6 @@ maintainers-logins = ["pmunts"]
 
 [[external]]
 kind = "system"
-hint = "Install from the Munts Technologies Debian Package Repository at http://repo.munts.com/debian11"
+hint = "Available at http://repo.munts.com/debian11 or http://repo.munts.com/muntsos/rpms"
 [external.origin."case(distribution)"]
-"debian" = ["muntsos-dev-beaglebone"]
+"debian|fedora|ubuntu" = ["muntsos-dev-beaglebone"]

--- a/index/mu/muntsos_dev_raspberrypi1/muntsos_dev_raspberrypi1-external.toml
+++ b/index/mu/muntsos_dev_raspberrypi1/muntsos_dev_raspberrypi1-external.toml
@@ -8,6 +8,6 @@ maintainers-logins = ["pmunts"]
 
 [[external]]
 kind = "system"
-hint = "Install from the Munts Technologies Debian Package Repository at http://repo.munts.com/debian11"
+hint = "Available at http://repo.munts.com/debian11 or http://repo.munts.com/muntsos/rpms"
 [external.origin."case(distribution)"]
-"debian" = ["muntsos-dev-raspberrypi1"]
+"debian|fedora|ubuntu" = ["muntsos-dev-raspberrypi1"]

--- a/index/mu/muntsos_dev_raspberrypi2/muntsos_dev_raspberrypi2-external.toml
+++ b/index/mu/muntsos_dev_raspberrypi2/muntsos_dev_raspberrypi2-external.toml
@@ -8,6 +8,6 @@ maintainers-logins = ["pmunts"]
 
 [[external]]
 kind = "system"
-hint = "Install from the Munts Technologies Debian Package Repository at http://repo.munts.com/debian11"
+hint = "Available at http://repo.munts.com/debian11 or http://repo.munts.com/muntsos/rpms"
 [external.origin."case(distribution)"]
-"debian" = ["muntsos-dev-raspberrypi2"]
+"debian|fedora|ubuntu" = ["muntsos-dev-raspberrypi2"]


### PR DESCRIPTION
MuntsOS Embedded Linux cross-toolchain RPM packages are now available for Fedora.