### PR TITLE
On macOS, get libgmp from Homebrew.

### DIFF
--- a/index/li/libgmp/libgmp-external.toml
+++ b/index/li/libgmp/libgmp-external.toml
@@ -10,6 +10,7 @@ kind = "system"
 "debian|ubuntu" = ["libgmp-dev"]
 arch = ["gmp"]
 msys2 = ["mingw-w64-x86_64-gmp"]
+homebrew = ["gmp"]
 
 [[external]]
 kind = "version-output"


### PR DESCRIPTION
This is stage 1 of what may be a tricky process!

While working on [libadalang2xml](https://github.com/simonjwright/libadalang2xml), I found that both langkit_support and libadalang require libgmp to build their relocatable libraries but can’t find it; gnatcoll_gmp manages this by supporting LDFLAGS, but the two packages above don’t. I’ll raise an issue (or two?), but that’ll take some time to work through and is really not ideal.