### PR TITLE
muntsos_xxxx release 2.0.0

### DIFF
--- a/index/mu/muntsos_beaglebone/muntsos_beaglebone-2.0.0.toml
+++ b/index/mu/muntsos_beaglebone/muntsos_beaglebone-2.0.0.toml
@@ -1,0 +1,33 @@
+name = "muntsos_beaglebone"
+description = "MuntsOS Embedded Linux support for BeagleBone targets"
+tags = ["muntsos", "embedded", "linux", "arm", "beaglebone"]
+version = "2.0.0"
+website = "https://github.com/pmunts/muntsos"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["aws.gpr", "libsimpleio.gpr"]
+
+[available."case(os)"]
+"linux" = true
+"..." = false
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+muntsos_dev_beaglebone = "*"
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch"]
+
+[origin]
+hashes = [
+"sha256:5dd2364998b4cae54c5ad5c315bb9d9bd708368603f186350967a09801ab5fd5",
+"sha512:66c3cabda92690dd44c1b29172f9d02d17d44d1ef5d5b8025069b0e8d7e86f372a2ec5ffeafbf7e09fa13a92aa7ef34c48d4e592b072183969aeca258f2b3a1f",
+]
+url = "http://repo.munts.com/alire/muntsos_beaglebone-2.0.0.tbz2"
+

--- a/index/mu/muntsos_raspberrypi1/muntsos_raspberrypi1-2.0.0.toml
+++ b/index/mu/muntsos_raspberrypi1/muntsos_raspberrypi1-2.0.0.toml
@@ -1,0 +1,33 @@
+name = "muntsos_raspberrypi1"
+description = "MuntsOS Embedded Linux support for RaspberryPi1 targets"
+tags = ["muntsos", "embedded", "linux", "arm", "raspberrypi1"]
+version = "2.0.0"
+website = "https://github.com/pmunts/muntsos"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["aws.gpr", "libsimpleio.gpr"]
+
+[available."case(os)"]
+"linux" = true
+"..." = false
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+muntsos_dev_raspberrypi1 = "*"
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch"]
+
+[origin]
+hashes = [
+"sha256:d5a5acb97f3e3df5c4775722e0732a0c71c94f76e809eb3cf0b802cc7a7639d1",
+"sha512:3a97be31a7b7858e8e973689b229e6afe9cc81e53bb5766cf6658d8ff28fb13f710fc4c315ec9a3c96b153a05baea4815dcf257a7b39ad4af016d9682c3be8b4",
+]
+url = "http://repo.munts.com/alire/muntsos_raspberrypi1-2.0.0.tbz2"
+

--- a/index/mu/muntsos_raspberrypi2/muntsos_raspberrypi2-2.0.0.toml
+++ b/index/mu/muntsos_raspberrypi2/muntsos_raspberrypi2-2.0.0.toml
@@ -1,0 +1,33 @@
+name = "muntsos_raspberrypi2"
+description = "MuntsOS Embedded Linux support for RaspberryPi2 targets"
+tags = ["muntsos", "embedded", "linux", "arm", "raspberrypi2"]
+version = "2.0.0"
+website = "https://github.com/pmunts/muntsos"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["aws.gpr", "libsimpleio.gpr"]
+
+[available."case(os)"]
+"linux" = true
+"..." = false
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+muntsos_dev_raspberrypi2 = "*"
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch"]
+
+[origin]
+hashes = [
+"sha256:ea4b24a2b4840992f781271781752f4995f8f4dd4951ce3ce9646fbb5f77cd58",
+"sha512:0d52bfe785aad2638f2895310cbd28cb55c7aec55a2d74ba2d7ff303fc6afe9e483b25d21edb92857b62b853b815035e4d4642a5a67d3e27f3b41d97ec3d8200",
+]
+url = "http://repo.munts.com/alire/muntsos_raspberrypi2-2.0.0.tbz2"
+

--- a/index/mu/muntsos_raspberrypi3/muntsos_raspberrypi3-2.0.0.toml
+++ b/index/mu/muntsos_raspberrypi3/muntsos_raspberrypi3-2.0.0.toml
@@ -1,0 +1,33 @@
+name = "muntsos_raspberrypi3"
+description = "MuntsOS Embedded Linux support for RaspberryPi3 targets"
+tags = ["muntsos", "embedded", "linux", "arm64", "raspberrypi3"]
+version = "2.0.0"
+website = "https://github.com/pmunts/muntsos"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["aws.gpr", "libsimpleio.gpr"]
+
+[available."case(os)"]
+"linux" = true
+"..." = false
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+muntsos_dev_aarch64 = "*"
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch"]
+
+[origin]
+hashes = [
+"sha256:70545f323ec3106d586e3fdd5a52c921d621ad5bd937be060250172f790e2c91",
+"sha512:687017d05a5c9ba2a8488b827260f15f207632a5771bd910a579572827cc25c352eabb07bcd39e92e693cb5068bd69331f579f1d618cfbdf38205123f9d2c3f9",
+]
+url = "http://repo.munts.com/alire/muntsos_raspberrypi3-2.0.0.tbz2"
+

--- a/index/mu/muntsos_raspberrypi4/muntsos_raspberrypi4-2.0.0.toml
+++ b/index/mu/muntsos_raspberrypi4/muntsos_raspberrypi4-2.0.0.toml
@@ -1,0 +1,33 @@
+name = "muntsos_raspberrypi4"
+description = "MuntsOS Embedded Linux support for RaspberryPi4 targets"
+tags = ["muntsos", "embedded", "linux", "arm64", "raspberrypi4"]
+version = "2.0.0"
+website = "https://github.com/pmunts/muntsos"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["aws.gpr", "libsimpleio.gpr"]
+
+[available."case(os)"]
+"linux" = true
+"..." = false
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+muntsos_dev_aarch64 = "*"
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch"]
+
+[origin]
+hashes = [
+"sha256:8dbfe71bd92fb766d6bc589cd9bbc37863ff28d225d3d330417369e5266425ec",
+"sha512:65860ba946f0d5ea1babf4f67646d88b96bad9870842bc1d875a856babb41094f8365d12ed3df3059cb308bb85386e1ab40efe759690e69c26fc52ed276bb781",
+]
+url = "http://repo.munts.com/alire/muntsos_raspberrypi4-2.0.0.tbz2"
+


### PR DESCRIPTION
Change a project to cross-compiled by copying default.gpr to the
project directory, instead of adding "for Target use" to the
project file.
