### PR TITLE
AdaCL module adacl release 5.12.0

### DIFF
--- a/index/ad/adacl/adacl-5.12.0.toml
+++ b/index/ad/adacl/adacl-5.12.0.toml
@@ -1,0 +1,55 @@
+name                        = "adacl"
+description                 = "Ada Class Library"
+long-description            = """A class library for Ada for those who like OO programming.
+
+Currently the following functionality is migrated to Ada 2022: 
+
+* getopt commandline argument parser
+* string utilities
+* trace utility
+* reference counted smart pointer
+* AUnit compatible informative asserts
+
+Development versions and testsuite available using the follwowing index:
+
+```sh
+alr index --add "git+https://github.com/krischik/alire-index.git#develop" --name krischik
+```
+
+Source code and testsuite available on [SourceForge](https://git.code.sf.net/p/adacl/git)
+"""
+version                     = "5.12.0"
+licenses                    = "GPL-3.0-or-later"
+authors                     = ["Martin Krischik <krischik@users.sourceforge.net>"]
+maintainers                 = ["Martin Krischik <krischik@users.sourceforge.net>"]
+maintainers-logins          = ["krischik"]
+website                     = "https://sourceforge.net/projects/adacl/"
+tags                        = ["library", "command-line", "trace", "logging", "string", "aunit", "assert", "ada2022"]
+
+[build-switches]
+development.runtime_checks  = "Overflow"
+release.runtime_checks      = "Default"
+validation.runtime_checks   = "Everything"
+development.contracts       = "Yes"
+release.contracts           = "Yes"
+validation.contracts        = "Yes"
+
+[[depends-on]]
+gnat                        = ">=12 & <2000"
+
+[[actions]]
+type                        = "test"
+command                     = ["alr", "run"]
+directory                   = "test"
+
+# vim: set textwidth=0 nowrap tabstop=8 shiftwidth=4 softtabstop=4 expandtab :
+# vim: set filetype=toml fileencoding=utf-8 fileformat=unix foldmethod=diff :
+# vim: set spell spelllang=en_gb :
+
+[origin]
+hashes = [
+"sha256:1c234e74c42b3023082b59974d959c4bb94f21ea02332db6b4a008016dcb2ac1",
+"sha512:b9ba3c03a3fe03e6accf0559b9f2852205fa4cfea867f8607435ee4f85e2a5e4669a75a02fe6ccd44c990ebaad7fa1e17f23f23ceb42d9a41c6038f3c3202f51",
+]
+url = "https://sourceforge.net/projects/adacl/files/Alire/adacl-5.12.0.tgz"
+


### PR DESCRIPTION
Improve asserts for AUnit checks. It's not possible to check every discrete type.