### PR TITLE
aws-23.0.0.toml: fix gnat dependency

### DIFF
--- a/index/aw/aws/aws-23.0.0.toml
+++ b/index/aw/aws/aws-23.0.0.toml
@@ -21,7 +21,7 @@ command = ["make", "setup", "ZLIB=false", "DEMOS=false",
 xmlada = "~23.0.0"
 gnatcoll = "~23.0.0"
 make = "*"
-gnat_native = ">=12"
+gnat = ">=12"
 openssl = "*"
 
 [gpr-externals]


### PR DESCRIPTION
Any kind of gnat can be used, not just `gnat_native`