### PR TITLE
Minor maintenance release.

### DIFF
--- a/index/li/libsimpleio/libsimpleio-1.21121.1.toml
+++ b/index/li/libsimpleio/libsimpleio-1.21121.1.toml
@@ -1,0 +1,28 @@
+name = "libsimpleio"
+description = "Linux Simple I/O Library for GNAT Ada"
+version = "1.21121.1"
+licenses = "BSD-1-Clause"
+website = "https://github.com/pmunts/libsimpleio"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["libsimpleio.gpr"]
+
+tags = ["embedded", "linux", "libsimpleio", "remoteio", "beaglebone",
+"pocketbeagle", "raspberrypi", "raspberry", "pi", "adc", "dac", "gpio",
+"hid", "i2c", "motor", "pwm", "sensor", "serial", "servo", "spi", "stepper",
+"watchdog"]
+
+[available."case(os)"]
+'linux' = true
+"..." = false
+
+[origin]
+hashes = [
+"sha256:3aedf14379f210f1d175c0e3194c950fef832221fe4b1afe0806f4db42104151",
+"sha512:e39686c1167d7aad185cc929d3f5d8477e6586bf97a3b642c37df9dfec885ab3253af44262f5768fd108cbfe6101adb78e99f3c5508b13aba7a4f7ccd21ad99f",
+]
+url = "http://repo.munts.com/alire/libsimpleio-1.21121.1.tbz2"
+

--- a/index/mc/mcp2221/mcp2221-1.21121.1.toml
+++ b/index/mc/mcp2221/mcp2221-1.21121.1.toml
@@ -1,0 +1,64 @@
+name = "mcp2221"
+description = "MCP2221 USB Raw HID I/O Expander Library for GNAT Ada"
+version = "1.21121.1"
+licenses = "BSD-1-Clause"
+website = "https://github.com/pmunts/libsimpleio"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["mcp2221.gpr"]
+
+tags = ["embedded", "linux", "mcp2221", "adc", "dac", "gpio", "i2c", "motor",
+"pwm", "sensor", "serial", "servo", "spi", "stepper"]
+
+[available."case(os)"]
+'linux|macos|windows' = true
+"..." = false
+
+# Linux needs libhidapi and libusb
+
+[[depends-on]]
+[depends-on."case(os)"."linux"]
+libhidapi = "*"
+
+[[depends-on]]
+[depends-on."case(os)"."linux"]
+libusb = "*"
+
+# MacOS needs Homebrew hidapi and libusb
+
+#[[depends-on]]
+#[depends-on."case(distribution)"."homebrew"]
+#libhidapi = "*"
+
+#[[depends-on]]
+#[depends-on."case(distribution)"."homebrew"]
+#libusb = "*"
+
+# On Linux, patch hid-hidapi.ads to link with libhidapi-hidraw.so
+
+[[actions."case(os)".linux]]
+type = "post-fetch"
+command = ["sh", "-c", "./src/scripts/postfetch.linux"]
+
+# On MacOS, copy .dylib files to ./lib
+
+[[actions."case(os)".macos]]
+type = "post-fetch"
+command = ["sh", "-c", "./src/scripts/postfetch.macos"]
+
+# On Windows, copy .DLL files to ./lib
+
+[[actions."case(os)".windows]]
+type = "post-fetch"
+command = ["sh", "-c", "./src/scripts/postfetch.windows"]
+
+[origin]
+hashes = [
+"sha256:e3f8a97916b82f42cbd9a985a691249d74d51429e9990db9e6da4c678b990860",
+"sha512:05b0bf751bd00c6a23f016311a2b409c1a32c0c9aa5db564ecc7d1c4f325b5ced319ac1c8a110cdfebc9d0fb6d5f2b63141055d7908febee1a78d6bcfa5871b6",
+]
+url = "http://repo.munts.com/alire/mcp2221-1.21121.1.tbz2"
+

--- a/index/re/remoteio/remoteio-1.21121.1.toml
+++ b/index/re/remoteio/remoteio-1.21121.1.toml
@@ -1,0 +1,64 @@
+name = "remoteio"
+description = "Remote I/O Protocol Client Library for GNAT Ada"
+version = "1.21121.1"
+licenses = "BSD-1-Clause"
+website = "https://github.com/pmunts/libsimpleio"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["remoteio.gpr"]
+
+tags = ["embedded", "linux", "remoteio", "adc", "dac", "gpio", "i2c", "motor",
+"pwm", "sensor", "serial", "servo", "spi", "stepper"]
+
+[available."case(os)"]
+'linux|macos|windows' = true
+"..." = false
+
+# Linux needs libhidapi and libusb
+
+[[depends-on]]
+[depends-on."case(os)"."linux"]
+libhidapi = "*"
+
+[[depends-on]]
+[depends-on."case(os)"."linux"]
+libusb = "*"
+
+# MacOS needs Homebrew hidapi and libusb
+
+#[[depends-on]]
+#[depends-on."case(distribution)"."homebrew"]
+#libhidapi = "*"
+
+#[[depends-on]]
+#[depends-on."case(distribution)"."homebrew"]
+#libusb = "*"
+
+# On Linux, patch hid-hidapi.ads to link with libhidapi-hidraw.so
+
+[[actions."case(os)".linux]]
+type = "post-fetch"
+command = ["sh", "-c", "./src/scripts/postfetch.linux"]
+
+# On MacOS, copy .dylib files to ./lib
+
+[[actions."case(os)".macos]]
+type = "post-fetch"
+command = ["sh", "-c", "./src/scripts/postfetch.macos"]
+
+# On Windows, copy .DLL files to ./lib
+
+[[actions."case(os)".windows]]
+type = "post-fetch"
+command = ["sh", "-c", "./src/scripts/postfetch.windows"]
+
+[origin]
+hashes = [
+"sha256:d62a4ba5ffcfb7255fdef993d6a71b5a824a7ce999b4fae27590195ac72197aa",
+"sha512:f8e39ba14ef49e20f9ed8dd585eecd49c192e46a61f96ef422e00d5484f73439c2994edf25d2f1f014c9fead6cf1e03fc7d84938b90b1f81c931cdfcd7d4e817",
+]
+url = "http://repo.munts.com/alire/remoteio-1.21121.1.tbz2"
+


### PR DESCRIPTION
libsimpleio release 1.21121.1
mcp2221 release 1.21121.1
remoteio release 1.21121.1

Reconciled some capitalization inconsistencies.  Also some other minor cleanups.

This exactly matches the general Debian package release munts-libsimpleio-2023.115.1-debian11-<arch>.deb.