### PR TITLE
Added base package for Ada ISO Library

### DIFF
--- a/index/is/iso_base/iso_base-1.0.0.toml
+++ b/index/is/iso_base/iso_base-1.0.0.toml
@@ -1,0 +1,13 @@
+name = "iso_base"
+description = "Base package for Ada ISO Project"
+version = "1.0"
+licenses = "MIT"
+website = "https://github.com/ada-iso/iso_base/"
+authors = ["AJ Ianozi"]
+maintainers = ["AJ Ianozi <aj@ianozi.com>"]
+maintainers-logins = ["aj-ianozi"]
+
+[origin]
+commit = "2267d997cdb05b0128d0577295bd7d2285f2601e"
+url = "git+https://github.com/ada-iso/iso_base.git"
+


### PR DESCRIPTION
This is my first time publishing to alire, so please let me know if I made any mistakes. This is the base (mostly empty) package but I'm hoping for it to be a dependency for two other alire items I'll be publishing: the almost-completed [iso_countries](https://github.com/ada-iso/iso_countries) and (the soon-to-be worked) on iso_curriences.  Before I attempt to publish iso_countries I'd like to have iso_base already in there.  Please let me know if you have any questions!