### PR TITLE
Releasing The Ada ISO Library

### DIFF
--- a/index/is/iso/iso-1.0.0.toml
+++ b/index/is/iso/iso-1.0.0.toml
@@ -1,0 +1,18 @@
+name = "iso"
+description = "ISO Standard references for Ada such as ISO 1366 country codes."
+version = "1.0.0"
+licenses = "MIT"
+website = "https://github.com/ada-iso/ada_iso/"
+tags = [ "countries", "iso-1366" ]
+
+authors = ["AJ Ianozi"]
+maintainers = ["AJ Ianozi <aj@ianozi.com>"]
+maintainers-logins = ["AJ-Ianozi"]
+
+[build-switches]
+"*".ada_version = "Ada2022"
+
+[origin]
+commit = "8c458179e6bc957f5219c0f9474123407cf947b4"
+url = "git+https://github.com/ada-iso/ada_iso.git"
+

--- a/index/is/iso/iso-1.0.0.toml
+++ b/index/is/iso/iso-1.0.0.toml
@@ -9,10 +9,7 @@ authors = ["AJ Ianozi"]
 maintainers = ["AJ Ianozi <aj@ianozi.com>"]
 maintainers-logins = ["AJ-Ianozi"]
 
-[build-switches]
-"*".ada_version = "Ada2022"
-
 [origin]
-commit = "8c458179e6bc957f5219c0f9474123407cf947b4"
+commit = "f54440c0264c1ef8dd8cccf37d1a8a6c15294fb7"
 url = "git+https://github.com/ada-iso/ada_iso.git"
 


### PR DESCRIPTION
This is the initial release for the [Ada ISO Library](https://github.com/ada-iso/ada_iso), which at the moment contains the implementation of ISO 3166-1 (Country Codes) with other implementations planned next (such as currencies).  This is the full library, with the countries implementation (as discussed on #803 ).