### PR TITLE
Add GtkAda 23.0.1

### DIFF
--- a/index/gt/gtkada/gtkada-23.0.1.toml
+++ b/index/gt/gtkada/gtkada-23.0.1.toml
@@ -1,0 +1,41 @@
+description = "An Ada graphical toolkit based on Gtk+"
+long-description = "This crate requires Gtk3+ >= 3.24.24"
+website = "https://github.com/adacore/gtkada"
+name = "gtkada"
+version = "23.0.1"
+authors = ["AdaCore"]
+licenses = "GPL-3.0-or-later WITH GCC-exception-3.1"
+maintainers = ["chouteau@adacore.com", "reznikmm@gmail.com"]
+maintainers-logins = ["Fabien-Chouteau", "reznikmm"]
+project-files = ["src/gtkada.gpr"]
+tags = ["gtk", "gui"]
+
+[configuration]
+disabled = true
+
+# Prepend PATH with pkg-config directory to stabilize GitHub CI
+[[actions]]
+type = "post-fetch"
+command = ["bash", "-c", "PATH=${DISTRIB_ROOT}/mingw64/bin:${PATH} ./configure"]
+
+# Generate gtkada-intl.adb to be able to build with gtkada.gpr
+[[actions]]
+type = "post-fetch"
+command = ["make", "src/gtkada-intl.adb"]
+
+[[depends-on]]
+make = "*"
+pkg_config = "*"
+libgtk3 = ">=3.24.24"
+
+[gpr-externals]
+LIBRARY_TYPE = ["static", "static-pic", "relocatable"]
+
+# Update PATH on Windows to help deps find .DLL files
+[environment.'case(os)'.windows.PATH]
+append = "${CRATE_ROOT}/src/obj/gtkada/relocatable"
+
+[origin]
+commit = "6c660db9feefa025f41d82ad5309603ead162866"
+url = "git+https://github.com/AdaCore/gtkada.git"
+


### PR DESCRIPTION
This release with renamed `shared.gpr` file to avoid name clashes and unblock `destiny-inventory-tool` project.