### PR TITLE
Use gcc version instead or "year" version for GNAT CE external crate

### DIFF
--- a/index/gn/gnat_external/gnat_external-external.toml
+++ b/index/gn/gnat_external/gnat_external-external.toml
@@ -6,8 +6,8 @@ maintainers-logins = ["mosteo"]
 
 [[external]]
 kind = "version-output"
-version-regexp = "^GNAT ([\\d\\.]+).*|^GNAT Community ([\\d]{4}).*"
-version-command = ["gnat", "--version"]
+version-regexp = "^[^0-9]+([\\d\\.]+).*for GNAT.*$"
+version-command = ["gcc", "--version"]
 provides = "gnat"
 
 # We do not want to have system external definitions because in typical systems


### PR DESCRIPTION
I'm not entirely sure about this one because of legacy, although I guess this should have been like this from the beginning.

With this change, community versions report the gcc version instead of the year, which will always be a problem for things like `"gnat>=11"`. 

With the CE no longer being released, this may be a non-issue already...