### PR TITLE
AdaCL module adacl release 5.13.0

### DIFF
--- a/index/ad/adacl/adacl-5.13.0.toml
+++ b/index/ad/adacl/adacl-5.13.0.toml
@@ -1,0 +1,60 @@
+name                        = "adacl"
+description                 = "Ada Class Library"
+long-description            = """A class library for Ada for those who like OO programming.
+
+Currently the following functionality is migrated to Ada 2022: 
+
+* Getopt commandline argument parser
+* String utilities
+* Trace utility
+* Smart pointer
+  * Reference counted
+  * Unique pointer
+  * Shared pointer 
+* AUnit compatible informative asserts
+
+See [GNATdoc](https://adacl.sourceforge.net/gnatdoc/adacl/index.html) for details.
+
+Development versions and testsuite available using the follwowing index:
+
+```sh
+alr index --add "git+https://github.com/krischik/alire-index.git#develop" --name krischik
+```
+
+Source code and testsuite available on [SourceForge](https://git.code.sf.net/p/adacl/git)
+"""
+version                     = "5.13.0"
+licenses                    = "GPL-3.0-or-later"
+authors                     = ["Martin Krischik <krischik@users.sourceforge.net>"]
+maintainers                 = ["Martin Krischik <krischik@users.sourceforge.net>"]
+maintainers-logins          = ["krischik"]
+website                     = "https://sourceforge.net/projects/adacl/"
+tags                        = ["library", "command-line", "trace", "logging", "string", "aunit", "assert", "container", "smart-pointer", "ada2022"]
+
+[build-switches]
+development.runtime_checks  = "Overflow"
+release.runtime_checks      = "Default"
+validation.runtime_checks   = "Everything"
+development.contracts       = "Yes"
+release.contracts           = "Yes"
+validation.contracts        = "Yes"
+
+[[depends-on]]
+gnat                        = ">=12 & <2000"
+
+[[actions]]
+type                        = "test"
+command                     = ["alr", "run"]
+directory                   = "test"
+
+# vim: set textwidth=0 nowrap tabstop=8 shiftwidth=4 softtabstop=4 expandtab :
+# vim: set filetype=toml fileencoding=utf-8 fileformat=unix foldmethod=diff :
+# vim: set spell spelllang=en_gb :
+
+[origin]
+hashes = [
+"sha256:f0ac574cd501cfc43bf40effb1af261905c9c0957b2d3d9b0627af1bb9795b5f",
+"sha512:3927b08e7217d64b9d33e455e6dc184e428520eef4ffb9c3f3c685c8285731e0be84aa18bcd21f6afd2757893ad48323ad91a50d454b6ade7bd7c2641a622a02",
+]
+url = "https://sourceforge.net/projects/adacl/files/Alire/adacl-5.13.0.tgz"
+


### PR DESCRIPTION
* use `gnatpp` to format the source.
* use `gnatdoc` to create documentation.
* Add unique pointer implementation based on the C++ `unique_ptr`
* Add shared pointer implementation based on the C++ `shared_ptr`
* Cleanup the old refcounted pointer so that the calls match.


