### PR TITLE
Update lea-0.87.0.toml

### DIFF
--- a/index/le/lea/lea-0.87.0.toml
+++ b/index/le/lea/lea-0.87.0.toml
@@ -10,7 +10,7 @@ licenses = "MIT"
 tags = ["lea", "editor"]
 
 project-files = ["lea_project_tree.gpr"]
-executables = ["lea.exe"]
+executables = ["lea"]
 
 [available.'case(os)']
 windows = true

--- a/index/le/lea/lea-0.87.0.toml
+++ b/index/le/lea/lea-0.87.0.toml
@@ -30,7 +30,7 @@ gwindows = "^1.4.0"
 [[depends-on]]
 zipada = "^58.0.0"
 [[depends-on]]
-gnat = "<10.3.1"
+gnat = "/=10.3.2"
 [[depends-on]]
 hac = "~0.22.0"
 

--- a/index/le/lea/lea-0.87.0.toml
+++ b/index/le/lea/lea-0.87.0.toml
@@ -10,6 +10,7 @@ licenses = "MIT"
 tags = ["lea", "editor"]
 
 project-files = ["lea_project_tree.gpr"]
+executables = ["lea.exe"]
 
 [available.'case(os)']
 windows = true


### PR DESCRIPTION
The choice of GNAT version is improved.
The previous state forced to a version of GNAT which is not supported by Alire.
This assumed a GNAT already installed outside of Alire. Absent that, the build failed.
Now the tactic is to avoid precise Alire-supported versions until one is working, which seems to be a successful approach (tested by removing all GNATs from the PATH).
