### PR TITLE
Mage v0.6.0: new Apps API

### DIFF
--- a/index/ma/mage/mage-0.6.0.toml
+++ b/index/ma/mage/mage-0.6.0.toml
@@ -1,0 +1,19 @@
+name = "mage"
+description = "Mini Ada Game Engine - A very simple game engine written in Ada"
+version = "0.6.0"
+
+website = "www.gitlab.com/leogermond/mage"
+
+authors = ["Leo Germond"]
+maintainers = ["Leo Germond <germond@adacore.com>"]
+maintainers-logins = ["leogermond"]
+
+licenses = "Apache-2.0"
+tags = ["game", "engine", "sdl"]
+[[depends-on]]
+sdlada = "^2.5.4-1"
+
+[origin]
+commit = "c8cf4e1177734f32360935e36de9ceb42617838e"
+url = "git+https://gitlab.com/leogermond/mage.git"
+

--- a/index/ma/mage_hat/mage_hat-0.3.0.toml
+++ b/index/ma/mage_hat/mage_hat-0.3.0.toml
@@ -1,0 +1,20 @@
+name = "mage_hat"
+description = "A hat that jumps around and behaves magically"
+version = "0.3.0"
+
+authors = ["Léo Germond"]
+maintainers = ["Léo Germond <germond@adacore.com>"]
+maintainers-logins = ["leogermond"]
+licenses = "Apache-2.0"
+tags = ["game", "demo", "magic"]
+website = "https://gitlab.com/leogermond/mage_hat"
+
+executables = ["mage_hat"]
+
+[[depends-on]]
+mage = "~0.6.0"
+
+[origin]
+commit = "255dc3724001a82c1b8f619f971663a8b67e5def"
+url = "git+https://gitlab.com/leogermond/mage_hat.git"
+


### PR DESCRIPTION
- mage 0.6.0
- mage_hat v0.3.0

This adds a new API to the mage lib, to simplify creating apps, on the format of a processing or arduino main loop definition.

This also provides a new version for the mage hat demo, which makes use of this new API.
