### PR TITLE
Don't abort checks on other environments on failure

### DIFF
--- a/.github/workflows/build-distros.yml
+++ b/.github/workflows/build-distros.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         tag:
           - arch-rolling              # Arch has its own recent GNAT and pacman

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         os:
           - macos-latest

--- a/.github/workflows/diff-release.yml
+++ b/.github/workflows/diff-release.yml
@@ -51,6 +51,6 @@ jobs:
         toolchain: --disable-assistant # We don't need the compiler
         branch: master
 
-    - name: Diff releases
+    - name: <<DIFF RELEASES>>
       run: ${{env.CHECKS_REPO}}/scripts/diff-release.sh || true # No deal breaker if failed
       shell: bash


### PR DESCRIPTION
This may reduce round-trip checks when fixing a PR, as all errors will become evident in one run.

Minor unrelated: enhanced visibility of the important step in the diff workflow.