### PR TITLE
Add Homebrew option for libsdl2*-externals.

### DIFF
--- a/index/li/libsdl2/libsdl2-external.toml
+++ b/index/li/libsdl2/libsdl2-external.toml
@@ -9,4 +9,5 @@ kind = "system"
     [external.origin.'case(distribution)']
     'debian|ubuntu' = ["libsdl2-dev"]
     'arch' = ["sdl2"]
+    'homebrew' = ["sdl2"]
     'msys2' = ["mingw-w64-x86_64-SDL2"]

--- a/index/li/libsdl2_image/libsdl2_image-external.toml
+++ b/index/li/libsdl2_image/libsdl2_image-external.toml
@@ -9,4 +9,5 @@ kind = "system"
     [external.origin.'case(distribution)']
     'debian|ubuntu' = ["libsdl2-image-dev"]
     'arch' = ["sdl2_image"]
+    'homebrew' = ["sdl2_image"]
     'msys2' = ["mingw-w64-x86_64-SDL2_image"]

--- a/index/li/libsdl2_ttf/libsdl2_ttf-external.toml
+++ b/index/li/libsdl2_ttf/libsdl2_ttf-external.toml
@@ -9,4 +9,5 @@ kind = "system"
     [external.origin.'case(distribution)']
     'debian|ubuntu' = ["libsdl2-ttf-dev"]
     'arch' = ["sdl2_ttf"]
+    'homebrew' = ["sdl2_ttf"]
     'msys2' = ["mingw-w64-x86_64-SDL2_ttf"]


### PR DESCRIPTION
  * index/li/libsdl2/libsdl2-external.toml (external): added 'homebrew' option, "sdl2".
  * index/li/libsdl2_image/libsdl2_image-external.toml: likewise, "sdl2_image".
  * index/li/libsdl2_ttf/libsdl2_ttf-external.toml: likewise, "sdl2_ttf".