### PR TITLE
Add libcurl external dependency

### DIFF
--- a/index/li/libcurl/libcurl-external.toml
+++ b/index/li/libcurl/libcurl-external.toml
@@ -1,0 +1,12 @@
+description = "CURL C library for transferring data with URLs"
+name = "libcurl"
+
+maintainers = ["Stephane Carrez <Stephane.Carrez@gmail.com>"]
+maintainers-logins = ["stcarrez"]
+
+[[external]]
+kind = "system"
+[external.origin."case(distribution)"]
+"fedora" = ["libcurl-devel"]
+"debian|ubuntu" = ["libcurl4-openssl-dev"]
+"msys2"         = ["mingw-w64-x86_64-curl"]


### PR DESCRIPTION
We have the `curl` crate which refers to the binary `curl` command but this is not the same as this propose libcurl which only refers to the library part. I would like to use it for the https://alire.ada.dev/crates/utilada_curl to have a correct dependency.
