### PR TITLE
Added Macports to some external origins.

### DIFF
--- a/index/li/libftdi1/libftdi1-external.toml
+++ b/index/li/libftdi1/libftdi1-external.toml
@@ -11,3 +11,4 @@ kind = "system"
 "debian|ubuntu" = ["libftdi1-dev"]
 arch = ["libftdi"]
 homebrew = ["libftdi"]
+macports = ["libftdi"]

--- a/index/li/libgmp/libgmp-external.toml
+++ b/index/li/libgmp/libgmp-external.toml
@@ -11,6 +11,7 @@ kind = "system"
 arch = ["gmp"]
 msys2 = ["mingw-w64-x86_64-gmp"]
 homebrew = ["gmp"]
+macports = ["gmp"]
 
 [[external]]
 kind = "version-output"

--- a/index/li/libhidapi/libhidapi-external.toml
+++ b/index/li/libhidapi/libhidapi-external.toml
@@ -11,3 +11,4 @@ kind = "system"
 "debian|ubuntu" = ["libhidapi-dev"]
 arch = ["hidapi"]
 homebrew = ["hidapi"]
+macports = ["hidapi"]

--- a/index/li/libsdl2/libsdl2-external.toml
+++ b/index/li/libsdl2/libsdl2-external.toml
@@ -10,4 +10,5 @@ kind = "system"
     'debian|ubuntu' = ["libsdl2-dev"]
     'arch' = ["sdl2"]
     'homebrew' = ["sdl2"]
+    'macports' = ["libsdl2"]
     'msys2' = ["mingw-w64-x86_64-SDL2"]

--- a/index/li/libsdl2_image/libsdl2_image-external.toml
+++ b/index/li/libsdl2_image/libsdl2_image-external.toml
@@ -10,4 +10,5 @@ kind = "system"
     'debian|ubuntu' = ["libsdl2-image-dev"]
     'arch' = ["sdl2_image"]
     'homebrew' = ["sdl2_image"]
+    'macports' = ["libsdl2_image"]
     'msys2' = ["mingw-w64-x86_64-SDL2_image"]

--- a/index/li/libsdl2_ttf/libsdl2_ttf-external.toml
+++ b/index/li/libsdl2_ttf/libsdl2_ttf-external.toml
@@ -10,4 +10,5 @@ kind = "system"
     'debian|ubuntu' = ["libsdl2-ttf-dev"]
     'arch' = ["sdl2_ttf"]
     'homebrew' = ["sdl2_ttf"]
+    'macports' = ["libsdl2_ttf"]
     'msys2' = ["mingw-w64-x86_64-SDL2_ttf"]

--- a/index/li/libtcl/libtcl-external.toml
+++ b/index/li/libtcl/libtcl-external.toml
@@ -13,3 +13,5 @@ kind = "system"
 "debian|ubuntu" = ["tcl8.6-dev"]
 "msys2" = ["mingw-w64-x86_64-tcl"]
 "homebrew" = ["tcl-tk"]
+"macports" = ["tcl"]
+

--- a/index/li/libtk/libtk-external.toml
+++ b/index/li/libtk/libtk-external.toml
@@ -13,3 +13,4 @@ kind="system"
 "debian|ubuntu" = ["tk8.6-dev"]
 "msys2" = ["mingw-w64-x86_64-tk"]
 "homebrew" = ["tcl-tk"]
+"macports" = ["tk"]

--- a/index/li/libusb/libusb-external.toml
+++ b/index/li/libusb/libusb-external.toml
@@ -11,3 +11,4 @@ kind = "system"
 "debian|ubuntu" = ["libusb-1.0-0-dev"]
 arch = ["libusb"]
 homebrew = ["libusb"]
+macports = ["libusb"]


### PR DESCRIPTION
These externals are those that already had homebrew settings.

  * index/li/libftdi1/libftdi1-external.toml
  * index/li/libgmp/libgmp-external.toml
  * index/li/libhidapi/libhidapi-external.toml
  * index/li/libsdl2/libsdl2-external.toml
  * index/li/libsdl2_image/libsdl2_image-external.toml
  * index/li/libsdl2_ttf/libsdl2_ttf-external.toml
  * index/li/libtcl/libtcl-external.toml
  * index/li/libtk/libtk-external.toml
  * index/li/libusb/libusb-external.toml