### PR TITLE
Ada Wiki 1.4.1

### DIFF
--- a/index/wi/wikiada/wikiada-1.4.1.toml
+++ b/index/wi/wikiada/wikiada-1.4.1.toml
@@ -1,0 +1,44 @@
+description = "Wiki Engine with parser and renderer for several wiki syntaxes"
+tags = ["wiki-engine", "markdown", "mediawiki", "dotclear", "html", "parser", "renderer"]
+name = "wikiada"
+version = "1.4.1"
+licenses = "Apache-2.0"
+authors = ["Stephane.Carrez@gmail.com"]
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+project-files = [".alire/wikiada.gpr"]
+website = "https://gitlab.com/stcarrez/ada-wiki"
+long-description = """
+
+[![Build Status](https://img.shields.io/endpoint?url=https://porion.vacs.fr/porion/api/v1/projects/ada-wiki/badges/build.json)](https://porion.vacs.fr/porion/projects/view/ada-wiki/summary)
+[![Test Status](https://img.shields.io/endpoint?url=https://porion.vacs.fr/porion/api/v1/projects/ada-wiki/badges/tests.json)](https://porion.vacs.fr/porion/projects/view/ada-wiki/xunits)
+[![Coverage](https://img.shields.io/endpoint?url=https://porion.vacs.fr/porion/api/v1/projects/ada-wiki/badges/coverage.json)](https://porion.vacs.fr/porion/projects/view/ada-wiki/summary)
+
+Ada Wiki is a small library that provides and focuses only on the Wiki engine.
+
+The library allows to:
+
+* Parse a wiki text such as Mediawiki, Creole, PhpBB, Dotclear and Google Code
+* Parse HTML content in embedded wiki text,
+* Filter out the wiki, HTML or text through customizable filters,
+* Render the wiki text in HTML, text or another wiki format
+
+The Ada Wiki library is used by [Ada Web Application](https://gitlab.com/stcarrez/ada-awa)
+for the implementation of the blog and wiki online plugins.
+
+"""
+
+[[depends-on]]
+utilada = "^2.5.0"
+
+[gpr-externals]
+WIKI_BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
+WIKI_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+
+[configuration]
+disabled = true
+
+[origin]
+commit = "c93445d7686e64412db29997724719f3208569b9"
+url = "git+https://gitlab.com/stcarrez/ada-wiki.git"
+


### PR DESCRIPTION
- Use WIKI_BUILD instead of BUILD for the control variable
- Update with 1.4.1 which fixes some HTML parsing