### PR TITLE
Add macOS bindings for openssl-external.

### DIFF
--- a/index/op/openssl/openssl-external.toml
+++ b/index/op/openssl/openssl-external.toml
@@ -14,3 +14,5 @@ kind = "system"
 "debian|ubuntu" = ["libssl-dev"]
 "arch" = ["openssl"]
 "msys2" = ["mingw-w64-x86_64-openssl"]
+"homebrew" = ["openssl"]
+"macports" = ["openssl"]


### PR DESCRIPTION
  * index/op/openssl/openssl-external.toml (external): add homebrew, macports.