### PR TITLE
Fix dependency on Ada Server Faces 1.6.0 unit crate

### DIFF
--- a/index/se/serverfaces_unit/serverfaces_unit-1.6.0.toml
+++ b/index/se/serverfaces_unit/serverfaces_unit-1.6.0.toml
@@ -29,7 +29,7 @@ on top of Ada Server Faces.
 
 [[depends-on]]
 security = "^1.5.0"
-serverfaces = "^1.7.0"
+serverfaces = "^1.6.0"
 servletada = "^1.7.0"
 utilada = "^2.6.0"
 utilada_unit = "^2.6.0"


### PR DESCRIPTION
The dependency on `serverfaces` for the `serverfaces_unit` was wrong and it was not detected by tools until trying to use it.