### PR TITLE
Update libgmp-external.toml - add Fedora detection

### DIFF
--- a/index/li/libgmp/libgmp-external.toml
+++ b/index/li/libgmp/libgmp-external.toml
@@ -12,6 +12,7 @@ arch = ["gmp"]
 msys2 = ["mingw-w64-x86_64-gmp"]
 homebrew = ["gmp"]
 macports = ["gmp"]
+fedora = ["gmp-devel"]
 
 [[external]]
 kind = "version-output"


### PR DESCRIPTION
As indicated in the open issue [#1320](https://github.com/alire-project/alire/issues/1320) the detection of `gmp` does not work with `alr` with the *Fedora Linux OS*. This PR adds the suggested missing config line to detect the Fedora `gmp-devel` library. 

Tested by editing the local cache file `~/.config/alire/indexes/community/repo/index/li/libgmp/libgmp-external.toml` to add the line suggested in the open issue:

```
fedora = ["gmp-devel"]
````
The detection then works as expected, and the previously failing build of `libadalang` on Fedora 38 (x86_64) now works.