### PR TITLE
Don't look for gprbuild from system provider.

### DIFF
--- a/index/gp/gprbuild/gprbuild-external.toml
+++ b/index/gp/gprbuild/gprbuild-external.toml
@@ -9,3 +9,10 @@ kind = "version-output"
 version-regexp = "^GPRBUILD ([\\d\\.-]+).*|^GPRBUILD Community ([\\d\\.-]+).*"
 version-command = ["gprbuild", "--version"]
 
+# Neither macOS distribution (Homebrew, MacPorts) provides gprbuild.
+[[external]]
+kind = "system"
+[external.origin.'case(os)']
+"freebsd" = ["gprbuild"]
+"linux"   = ["gprbuild"]
+"windows" = ["gprbuild"]

--- a/index/gp/gprbuild/gprbuild-external.toml
+++ b/index/gp/gprbuild/gprbuild-external.toml
@@ -9,6 +9,3 @@ kind = "version-output"
 version-regexp = "^GPRBUILD ([\\d\\.-]+).*|^GPRBUILD Community ([\\d\\.-]+).*"
 version-command = ["gprbuild", "--version"]
 
-[[external]]
-kind = "system"
-origin = ["gprbuild"]


### PR DESCRIPTION
Because the manifest currently asks for Alire to try to download gprbuild from the system package manager, alr <anything> spends several fruitless seconds trying to find gprbuild. This PR removes the 'system' external from gprbuild-external.toml.