### PR TITLE
New crate intl for a small NLS library on top of gettext (3)

### DIFF
--- a/index/in/intl/intl-1.0.0.toml
+++ b/index/in/intl/intl-1.0.0.toml
@@ -1,0 +1,91 @@
+name = "intl"
+description = "NLS thin Ada binding"
+version = "1.0.0"
+long-description = """
+
+This is a small Ada library that provides NLS support by using
+[gettext (3)](https://linux.die.net/man/3/gettext),
+[textdomain (3)](https://linux.die.net/man/3/textdomain) and
+[bindtextdomain (3)](https://linux.die.net/man/3/bindtextdomain).
+
+When NLS is not supported or disabled, the Ada library implements the
+NLS operations by using empty suitable stubs that skip the NLS transformation
+and emit the English default message.
+
+## Using the library
+
+The first step in using the NLS library is to call the `Initialize` procedure
+that handles the setup of `textdomain` and `bindtextdomain` to configure the
+language according to the user's locale.  The program localized messages are
+stored in a catalog file that is created by `msginit (1)` and `msgfmt (1)` tools.
+In most cases catalog file are identified by a unique name that must be given
+to the `Initialize` procedure (below, it will be `mytool`).
+
+```
+with Intl;
+...
+   PROG_NAME : constant String := "mytool";
+ ...
+   Intl.Initialize (PROG_NAME, "/usr/share/locale");
+```
+
+To localize a message, the `"-"` function is provided to encapsulate the call
+to the [gettext (3)](https://linux.die.net/man/3/gettext) method.  If the message
+is translated and the catalog contains it in the user's language, it will be
+converted by `gettext` and the `"-"` function returns the localized message.
+
+```
+with GNAT.IO;
+   ...
+   function "-" (Message : in String) return String is (Intl."-" (Message));
+   ...
+   GNAT.IO.Put_Line (-("Hello world!"));
+```
+
+To build the message translation file (`PO files`), a tool can be used to extract
+from the source code the default messages.  This process is
+explained in the [GNU gettext](https://www.gnu.org/software/gettext/manual/) documentation.
+
+"""
+
+authors = ["Stephane.Carrez@gmail.com"]
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+licenses = "Apache-2.0"
+website = "https://gitlab.com/stcarrez/ada-intl"
+tags = ["i18n", "nls", "bindings"]
+
+[gpr-externals]
+INTL_USE_NLS = ["yes", "no"]
+INTL_USE_LIBINTL = ["yes", "no"]
+
+[gpr-set-externals."case(os)".linux]
+INTL_USE_NLS = "yes"
+INTL_USE_LIBINTL = "no"
+
+[gpr-set-externals."case(os)".freebsd]
+INTL_USE_NLS = "yes"
+INTL_USE_LIBINTL = "yes"
+
+# Note: for NetBSD, we could use:
+# [gpr-set-externals."case(os)".netbsd]
+# INTL_USE_NLS = "yes"
+# INTL_USE_LIBINTL = "yes"
+
+# Note: on MacOS and Windows, you can override this and use the NLS
+# support if you install the GNU gettext package.
+[gpr-set-externals."case(os)".windows]
+INTL_USE_NLS = "no"
+INTL_USE_LIBINTL = "no"
+
+[gpr-set-externals."case(os)".macos]
+INTL_USE_NLS = "no"
+INTL_USE_LIBINTL = "no"
+
+[configuration]
+disabled = true
+
+[origin]
+commit = "a6689c26ade1aba437dbb1695741483ea944912b"
+url = "git+https://gitlab.com/stcarrez/ada-intl.git"
+


### PR DESCRIPTION
This provides the `Intl` Ada package that gives access to the `gettext (3)` function in order to localize a program. It is intended to be used on system which do have `gettext` BUT also on systems where this is not available. On systems where `gettext (3)` is not available, the `Intl` package provides specific implementation that is suitable to use default English messages.