### PR TITLE
Match more version of gnat/gprbuild when using external versions

### DIFF
--- a/index/gn/gnat_external/gnat_external-external.toml
+++ b/index/gn/gnat_external/gnat_external-external.toml
@@ -6,7 +6,7 @@ maintainers-logins = ["mosteo"]
 
 [[external]]
 kind = "version-output"
-version-regexp = "^GNAT ([\\d\\.]+).*|^GNAT Community ([\\d]{4}).*"
+version-regexp = "^GNAT\\D*([\\d\\.]+).*"
 version-command = ["gnat", "--version"]
 provides = "gnat"
 

--- a/index/gp/gprbuild/gprbuild-external.toml
+++ b/index/gp/gprbuild/gprbuild-external.toml
@@ -6,7 +6,7 @@ maintainers-logins = ["mosteo"]
 
 [[external]]
 kind = "version-output"
-version-regexp = "^GPRBUILD ([\\d\\.-]+).*|^GPRBUILD Community ([\\d\\.-]+).*"
+version-regexp = "^GPRBUILD\\D*([\\d\\.-]+).*"
 version-command = ["gprbuild", "--version"]
 
 # Neither macOS distribution (Homebrew, MacPorts) provides gprbuild.


### PR DESCRIPTION
This expands the list of GNAT/GPRBUILD versions that can be matched by the external crates. For example the version of gprbuild that is installed by apt on Ubuntu 22.04