### PR TITLE
Add magicada crate for an Ada binding to the libmagic (3) library on Unix

### DIFF
--- a/index/li/libmagic/libmagic-external.toml
+++ b/index/li/libmagic/libmagic-external.toml
@@ -1,0 +1,11 @@
+description = "Recognize the type of data in a file using 'magic' numbers"
+name = "libmagic"
+
+maintainers = ["Stephane Carrez <Stephane.Carrez@gmail.com>"]
+maintainers-logins = ["stcarrez"]
+
+[[external]]
+kind = "system"
+
+[external.origin."case(distribution)"]
+"debian|ubuntu" = ["libmagic-dev"]

--- a/index/ma/magicada/magicada-1.0.0.toml
+++ b/index/ma/magicada/magicada-1.0.0.toml
@@ -1,0 +1,71 @@
+name = "magicada"
+description = "Magic Number Recognition Library Ada binding"
+version = "1.0.0"
+long-description = """
+
+Small Ada binding library to the [libmagic (3)](https://linux.die.net/man/3/libmagic)
+library which is used by the implementation of the
+[file (1)](https://linux.die.net/man/1/file) command.
+
+To simplify and help in the use of the magic Ada library, the
+`Magic.Manager` package encapsulates the management of the libmagic library
+and provides high level simple operations to hide the details of interacting
+with the C library.  The package defines the `Magic_Manager` tagged record
+that takes care of the C library interaction and cleaning of the libmagic
+library once the manager is no longer required.  To use it, declare the
+instance and initialize it with the `Initialize` procedure:
+
+```Ada
+ with Magic.Manager;
+ ...
+    Mgr : Magic.Manager.Magic_Manager;
+    ...
+       Mgr.Initialize (Magic.MAGIC_MIME, Magic.DEFAULT_PATH);
+```
+
+The first parameter defines a set of flags represented by the `Magic.Flags`
+type to control various options of the libmagic library.   The second
+parameter indicates the default path to the magic file
+(see [magic (5)](https://linux.die.net/man/5/magic)).
+Once configured, the `Identify` functions can be used to identify a content.
+For the first form, a path of the file is given:
+
+```Ada
+ Mime : constant String := Mgr.Identify ("file.ads");
+```
+
+With the second form, a `Stream_Element_Array` with the content to identify
+is given to the function.
+
+## Example
+
+- [examples.adb](https://gitlab.com/stcarrez/ada-libmagic/-/blob/main/examples/src/examples.adb?ref_type=heads)
+
+"""
+
+authors = ["Stephane.Carrez@gmail.com"]
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+licenses = "Apache-2.0"
+website = "https://gitlab.com/stcarrez/ada-libmagic"
+tags = ["magic", "file", "bindings"]
+
+[gpr-externals]
+MAGICADA_BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
+MAGICADA_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+
+[available.'case(os)']
+linux = true
+freebsd = true
+'...' = false
+
+[[depends-on]]
+libmagic = "*"
+
+[configuration]
+disabled = true
+
+[origin]
+commit = "8a67ea102940bb05ea8eae783f04eb6e8cb33b56"
+url = "git+https://gitlab.com/stcarrez/ada-libmagic.git"
+


### PR DESCRIPTION
The library provides a thin binding that allows to access the libmagic (3) functions and a higher level more Ada friendly API to access the library.  libmagic (3) is used by the file (1) command on Unix.
