### PR TITLE
MuntsOS Embedded Linux Toolchain updates

### DIFF
--- a/index/mu/muntsos_beaglebone/muntsos_beaglebone-9.0.0.toml
+++ b/index/mu/muntsos_beaglebone/muntsos_beaglebone-9.0.0.toml
@@ -1,0 +1,33 @@
+name = "muntsos_beaglebone"
+description = "MuntsOS Embedded Linux support for BeagleBone targets"
+tags = ["muntsos", "embedded", "linux", "arm", "beaglebone"]
+version = "9.0.0"
+website = "https://github.com/pmunts/muntsos"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["aws.gpr", "libsimpleio.gpr"]
+
+[available."case(os)"]
+"linux" = true
+"..." = false
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+muntsos_dev_ctng_beaglebone = "*"
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch"]
+
+[origin]
+hashes = [
+"sha256:27edcdca9509d39c369407c1e3dcba8ca994c27c4a5d8661ca9a12627c7dbb20",
+"sha512:58acb1e70f9779a9ef9a781173253e72d1c4001d47220132b27ffddfd154cc4da89e41d6f50bc3cee32a3597202b619f2b1fd95e99f9bd2d2d18e5a5913f750d",
+]
+url = "http://repo.munts.com/alire/muntsos_beaglebone-9.0.0.tbz2"
+

--- a/index/mu/muntsos_dev_aarch64/muntsos_dev_aarch64-external.toml
+++ b/index/mu/muntsos_dev_aarch64/muntsos_dev_aarch64-external.toml
@@ -8,6 +8,7 @@ maintainers-logins = ["pmunts"]
 
 [[external]]
 kind = "system"
-hint = "Available at http://repo.munts.com/debian11 or http://repo.munts.com/muntsos/rpms"
+hint = "Available at http://repo.munts.com/debian12 or http://repo.munts.com/muntsos/rpms"
 [external.origin."case(distribution)"]
-"centos|debian|fedora|rhel|ubuntu" = ["muntsos-dev-aarch64"]
+"debian|ubuntu" = ["muntsos-dev-ctng-aarch64"]
+"centos|fedora|rhel" = ["muntsos-aarch64"]

--- a/index/mu/muntsos_dev_beaglebone/muntsos_dev_beaglebone-external.toml
+++ b/index/mu/muntsos_dev_beaglebone/muntsos_dev_beaglebone-external.toml
@@ -8,6 +8,7 @@ maintainers-logins = ["pmunts"]
 
 [[external]]
 kind = "system"
-hint = "Available at http://repo.munts.com/debian11 or http://repo.munts.com/muntsos/rpms"
+hint = "Available at http://repo.munts.com/debian12 or http://repo.munts.com/muntsos/rpms"
 [external.origin."case(distribution)"]
-"centos|debian|fedora|rhel|ubuntu" = ["muntsos-dev-beaglebone"]
+"debian|ubuntu" = ["muntsos-dev-ctng-beaglebone"]
+"centos|fedora|rhel" = ["muntsos-beaglebone"]

--- a/index/mu/muntsos_dev_raspberrypi1/muntsos_dev_raspberrypi1-external.toml
+++ b/index/mu/muntsos_dev_raspberrypi1/muntsos_dev_raspberrypi1-external.toml
@@ -8,6 +8,7 @@ maintainers-logins = ["pmunts"]
 
 [[external]]
 kind = "system"
-hint = "Available at http://repo.munts.com/debian11 or http://repo.munts.com/muntsos/rpms"
+hint = "Available at http://repo.munts.com/debian12 or http://repo.munts.com/muntsos/rpms"
 [external.origin."case(distribution)"]
-"centos|debian|fedora|rhel|ubuntu" = ["muntsos-dev-raspberrypi1"]
+"debian|ubuntu" = ["muntsos-dev-ctng-raspberrypi1"]
+"centos|fedora|rhel" = ["muntsos-raspberrypi1"]

--- a/index/mu/muntsos_dev_raspberrypi2/muntsos_dev_raspberrypi2-external.toml
+++ b/index/mu/muntsos_dev_raspberrypi2/muntsos_dev_raspberrypi2-external.toml
@@ -8,6 +8,7 @@ maintainers-logins = ["pmunts"]
 
 [[external]]
 kind = "system"
-hint = "Available at http://repo.munts.com/debian11 or http://repo.munts.com/muntsos/rpms"
+hint = "Available at http://repo.munts.com/debian12 or http://repo.munts.com/muntsos/rpms"
 [external.origin."case(distribution)"]
-"centos|debian|fedora|rhel|ubuntu" = ["muntsos-dev-raspberrypi2"]
+"debian|ubuntu" = ["muntsos-dev-ctng-raspberrypi2"]
+"centos|fedora|rhel" = ["muntsos-raspberrypi2"]

--- a/index/mu/muntsos_orangepizero2w/muntsos_orangepizero2w-9.0.0.toml
+++ b/index/mu/muntsos_orangepizero2w/muntsos_orangepizero2w-9.0.0.toml
@@ -1,0 +1,33 @@
+name = "muntsos_orangepizero2w"
+description = "MuntsOS Embedded Linux support for OrangePiZero2W targets"
+tags = ["muntsos", "embedded", "linux", "arm64", "orangepizero2w"]
+version = "9.0.0"
+website = "https://github.com/pmunts/muntsos"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["aws.gpr", "libsimpleio.gpr"]
+
+[available."case(os)"]
+"linux" = true
+"..." = false
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+muntsos_dev_ctng_aarch64 = "*"
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch"]
+
+[origin]
+hashes = [
+"sha256:180d373027fd987838ed98960ba4a2b1b5ccb673e3a2089da2329a67ad21e58a",
+"sha512:488a94ae90419f6cce37126e1cf3b73bb7273d58e7fc1a0838dbcbf2b29ab6abf31a2efa6f1e79e1d623df168b3d3b8f2402b8ab72704fa309cf0770f5d86e36",
+]
+url = "http://repo.munts.com/alire/muntsos_orangepizero2w-9.0.0.tbz2"
+

--- a/index/mu/muntsos_pocketbeagle/muntsos_pocketbeagle-9.0.0.toml
+++ b/index/mu/muntsos_pocketbeagle/muntsos_pocketbeagle-9.0.0.toml
@@ -1,0 +1,33 @@
+name = "muntsos_pocketbeagle"
+description = "MuntsOS Embedded Linux support for PocketBeagle targets"
+tags = ["muntsos", "embedded", "linux", "arm", "pocketbeagle"]
+version = "9.0.0"
+website = "https://github.com/pmunts/muntsos"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["aws.gpr", "libsimpleio.gpr"]
+
+[available."case(os)"]
+"linux" = true
+"..." = false
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+muntsos_dev_ctng_beaglebone = "*"
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch"]
+
+[origin]
+hashes = [
+"sha256:2a6d1ae628a9e559b2f0f41ffadcae2fc68eaea6596f24473de3d82ad7f8f619",
+"sha512:664be64859a9425eb4c2c2439d4714904a20ccd459a363d30ea44a72b71db1752108d36f5ab53862d7830ba86de0d327cf557d48b42831cf312b804301e1f476",
+]
+url = "http://repo.munts.com/alire/muntsos_pocketbeagle-9.0.0.tbz2"
+

--- a/index/mu/muntsos_raspberrypi1/muntsos_raspberrypi1-9.0.0.toml
+++ b/index/mu/muntsos_raspberrypi1/muntsos_raspberrypi1-9.0.0.toml
@@ -1,0 +1,33 @@
+name = "muntsos_raspberrypi1"
+description = "MuntsOS Embedded Linux support for RaspberryPi1 targets"
+tags = ["muntsos", "embedded", "linux", "arm", "raspberrypi1"]
+version = "9.0.0"
+website = "https://github.com/pmunts/muntsos"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["aws.gpr", "libsimpleio.gpr"]
+
+[available."case(os)"]
+"linux" = true
+"..." = false
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+muntsos_dev_ctng_raspberrypi1 = "*"
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch"]
+
+[origin]
+hashes = [
+"sha256:984e2cef7c6cc2c111dcae975cfe678bb8999f8e9c63a32d86a532ba563ab4aa",
+"sha512:27daeef317fa27efece3ffdafdfa3116bb9352327cfe157837c7d88ce7a7c309a9283a149fc25c8d473fc97864e6776414d83fd9d596b9304dc15c321832a398",
+]
+url = "http://repo.munts.com/alire/muntsos_raspberrypi1-9.0.0.tbz2"
+

--- a/index/mu/muntsos_raspberrypi2/muntsos_raspberrypi2-9.0.0.toml
+++ b/index/mu/muntsos_raspberrypi2/muntsos_raspberrypi2-9.0.0.toml
@@ -1,0 +1,33 @@
+name = "muntsos_raspberrypi2"
+description = "MuntsOS Embedded Linux support for RaspberryPi2 targets"
+tags = ["muntsos", "embedded", "linux", "arm", "raspberrypi2"]
+version = "9.0.0"
+website = "https://github.com/pmunts/muntsos"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["aws.gpr", "libsimpleio.gpr"]
+
+[available."case(os)"]
+"linux" = true
+"..." = false
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+muntsos_dev_ctng_raspberrypi2 = "*"
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch"]
+
+[origin]
+hashes = [
+"sha256:2702589ca23f7ed9433f60d2498b00f3065ff8e13822f02257029bd87bfe1912",
+"sha512:bae72e2e0a39533012459ef4bff708171e0d7def9acda55a1693941e0eba9965b517291bd98ae4d6234575db512c1f4ce1e5f71295c238bf437c59f51967668b",
+]
+url = "http://repo.munts.com/alire/muntsos_raspberrypi2-9.0.0.tbz2"
+

--- a/index/mu/muntsos_raspberrypi3/muntsos_raspberrypi3-9.0.0.toml
+++ b/index/mu/muntsos_raspberrypi3/muntsos_raspberrypi3-9.0.0.toml
@@ -1,0 +1,33 @@
+name = "muntsos_raspberrypi3"
+description = "MuntsOS Embedded Linux support for RaspberryPi3 targets"
+tags = ["muntsos", "embedded", "linux", "arm64", "raspberrypi3"]
+version = "9.0.0"
+website = "https://github.com/pmunts/muntsos"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["aws.gpr", "libsimpleio.gpr"]
+
+[available."case(os)"]
+"linux" = true
+"..." = false
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+muntsos_dev_ctng_aarch64 = "*"
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch"]
+
+[origin]
+hashes = [
+"sha256:99cb31fc9cea3fed38d635fc1eefedcf8e6f77ce179cc9e6128ed18191251efd",
+"sha512:a29dfe2c333ff48d049706f8525b379ad5d6fc14e26e6c7089d73489da5ee0063c40bc6acd0a0df2889e74fe24f8cf7fffb5d2b1b967aa1285607bd40975bc45",
+]
+url = "http://repo.munts.com/alire/muntsos_raspberrypi3-9.0.0.tbz2"
+

--- a/index/mu/muntsos_raspberrypi4/muntsos_raspberrypi4-9.0.0.toml
+++ b/index/mu/muntsos_raspberrypi4/muntsos_raspberrypi4-9.0.0.toml
@@ -1,0 +1,33 @@
+name = "muntsos_raspberrypi4"
+description = "MuntsOS Embedded Linux support for RaspberryPi4 targets"
+tags = ["muntsos", "embedded", "linux", "arm64", "raspberrypi4"]
+version = "9.0.0"
+website = "https://github.com/pmunts/muntsos"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["aws.gpr", "libsimpleio.gpr"]
+
+[available."case(os)"]
+"linux" = true
+"..." = false
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+muntsos_dev_ctng_aarch64 = "*"
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch"]
+
+[origin]
+hashes = [
+"sha256:3744e9d09f755f08b321c1dedac6a31c414d9b8ed8cca2f70bdd55ad0e185e02",
+"sha512:3458a43c0233773e386f394bc063c61e16b67827495cc60636662260b0f80e55673580ca4e51ecd94044273848f8a6472eebead47ee736e3de174cd5582a3067",
+]
+url = "http://repo.munts.com/alire/muntsos_raspberrypi4-9.0.0.tbz2"
+

--- a/index/mu/muntsos_raspberrypizero2w/muntsos_raspberrypizero2w-9.0.0.toml
+++ b/index/mu/muntsos_raspberrypizero2w/muntsos_raspberrypizero2w-9.0.0.toml
@@ -1,0 +1,33 @@
+name = "muntsos_raspberrypizero2w"
+description = "MuntsOS Embedded Linux support for RaspberryPiZero2W targets"
+tags = ["muntsos", "embedded", "linux", "arm64", "raspberrypi3"]
+version = "9.0.0"
+website = "https://github.com/pmunts/muntsos"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["aws.gpr", "libsimpleio.gpr"]
+
+[available."case(os)"]
+"linux" = true
+"..." = false
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+muntsos_dev_ctng_aarch64 = "*"
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch"]
+
+[origin]
+hashes = [
+"sha256:041cd94555b6b7fa2f4f5cd3e81d6910c17df506b35492cdd155ddf08b96c163",
+"sha512:453038e5d308cbcf26e428c20d9f3634bd46d0c12738a07ca9c4fd1275e267d4853e8c3e4cabd5648aa809d820f52affa1e8c4b77c7e287307a857ecde494fe4",
+]
+url = "http://repo.munts.com/alire/muntsos_raspberrypizero2w-9.0.0.tbz2"
+


### PR DESCRIPTION
Updated for Debian 12 / Crosstool-NG 1.26.0 / GCC 13.2.0.