### PR TITLE
Add suse distribution to libgmp-external

### DIFF
--- a/index/li/libgmp/libgmp-external.toml
+++ b/index/li/libgmp/libgmp-external.toml
@@ -13,6 +13,7 @@ msys2 = ["mingw-w64-x86_64-gmp"]
 homebrew = ["gmp"]
 macports = ["gmp"]
 fedora = ["gmp-devel"]
+suse = ["gmp-devel"]
 
 [[external]]
 kind = "version-output"


### PR DESCRIPTION
Install the `gmp-devel` system package on suse distributions.