### PR TITLE
muntsos_xxxx release 9.1.0

### DIFF
--- a/index/mu/muntsos_aarch64/muntsos_aarch64-9.1.0.toml
+++ b/index/mu/muntsos_aarch64/muntsos_aarch64-9.1.0.toml
@@ -1,0 +1,33 @@
+name = "muntsos_aarch64"
+description = "MuntsOS Embedded Linux support for AArch64 targets"
+tags = ["muntsos", "embedded", "linux", "arm64", "aarch64"]
+version = "9.1.0"
+website = "https://github.com/pmunts/muntsos"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["aws.gpr", "libsimpleio.gpr"]
+
+[available."case(os)"]
+"linux" = true
+"..." = false
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+muntsos_dev_aarch64 = "*"
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch"]
+
+[origin]
+hashes = [
+"sha256:8e6dd63dc3b90bace90ec66a1d54f0389a90ecba5a74cbaba220ae4bfe864723",
+"sha512:0e31afec64257607ccfe748ed89a86f85e62100215e40c8be27cd403d1e431ddfadf8f809958da44245d041a3866f3d0b00644bceea80b722da4073ff807fa99",
+]
+url = "http://repo.munts.com/alire/muntsos_aarch64-9.1.0.tbz2"
+

--- a/index/mu/muntsos_beaglebone/muntsos_beaglebone-9.1.0.toml
+++ b/index/mu/muntsos_beaglebone/muntsos_beaglebone-9.1.0.toml
@@ -1,0 +1,33 @@
+name = "muntsos_beaglebone"
+description = "MuntsOS Embedded Linux support for BeagleBone targets"
+tags = ["muntsos", "embedded", "linux", "arm", "beaglebone"]
+version = "9.1.0"
+website = "https://github.com/pmunts/muntsos"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["aws.gpr", "libsimpleio.gpr"]
+
+[available."case(os)"]
+"linux" = true
+"..." = false
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+muntsos_dev_beaglebone = "*"
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch"]
+
+[origin]
+hashes = [
+"sha256:053848d0f38fcbbb0149e897697288b5bb2b6573b95a83842fe2f8c6b85114c4",
+"sha512:6e5f85e23df95b67d002a682417cb19ff8803db9830faec0d9f00d216f8262573dc3a3b7f9c55510e0efa0e33b0ca07accfbd8682185d5afff6d9daca088b8a4",
+]
+url = "http://repo.munts.com/alire/muntsos_beaglebone-9.1.0.tbz2"
+

--- a/index/mu/muntsos_raspberrypi1/muntsos_raspberrypi1-9.1.0.toml
+++ b/index/mu/muntsos_raspberrypi1/muntsos_raspberrypi1-9.1.0.toml
@@ -1,0 +1,33 @@
+name = "muntsos_raspberrypi1"
+description = "MuntsOS Embedded Linux support for RaspberryPi1 targets"
+tags = ["muntsos", "embedded", "linux", "arm", "raspberrypi1"]
+version = "9.1.0"
+website = "https://github.com/pmunts/muntsos"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["aws.gpr", "libsimpleio.gpr"]
+
+[available."case(os)"]
+"linux" = true
+"..." = false
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+muntsos_dev_raspberrypi1 = "*"
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch"]
+
+[origin]
+hashes = [
+"sha256:f3c9199dee4c58bad47f92051ad09bcac5d1943fa7f3b4593a9cc62b30b7f437",
+"sha512:ad517a32593e7cafa3fd24f45f68eccb78a29d970a413fda02f5d32a876360aa90f67715640405ee949b9d424b5af4e6afc00e48d21b01a7d6a634eea34fcad6",
+]
+url = "http://repo.munts.com/alire/muntsos_raspberrypi1-9.1.0.tbz2"
+

--- a/index/mu/muntsos_raspberrypi2/muntsos_raspberrypi2-9.1.0.toml
+++ b/index/mu/muntsos_raspberrypi2/muntsos_raspberrypi2-9.1.0.toml
@@ -1,0 +1,33 @@
+name = "muntsos_raspberrypi2"
+description = "MuntsOS Embedded Linux support for RaspberryPi2 targets"
+tags = ["muntsos", "embedded", "linux", "arm", "raspberrypi2"]
+version = "9.1.0"
+website = "https://github.com/pmunts/muntsos"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["aws.gpr", "libsimpleio.gpr"]
+
+[available."case(os)"]
+"linux" = true
+"..." = false
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+muntsos_dev_raspberrypi2 = "*"
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch"]
+
+[origin]
+hashes = [
+"sha256:adf9b8c8d2bf8e70804a1471bf5b37c94c48772b91d35ba0899b115db1792fcf",
+"sha512:0360d5045e139f311d65291e6bcb056944fa0c130c37b3d7cf9d30ea259ef611ba2664b395a6aa313cc1a737dc1f075675d679511c04fb2275ecaa905558d10b",
+]
+url = "http://repo.munts.com/alire/muntsos_raspberrypi2-9.1.0.tbz2"
+

--- a/index/mu/muntsos_raspberrypi3/muntsos_raspberrypi3-9.1.0.toml
+++ b/index/mu/muntsos_raspberrypi3/muntsos_raspberrypi3-9.1.0.toml
@@ -1,0 +1,33 @@
+name = "muntsos_raspberrypi3"
+description = "MuntsOS Embedded Linux support for RaspberryPi3 targets"
+tags = ["muntsos", "embedded", "linux", "arm64", "raspberrypi3"]
+version = "9.1.0"
+website = "https://github.com/pmunts/muntsos"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["aws.gpr", "libsimpleio.gpr"]
+
+[available."case(os)"]
+"linux" = true
+"..." = false
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+muntsos_dev_aarch64 = "*"
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch"]
+
+[origin]
+hashes = [
+"sha256:5acfecc8bc540b1a95663677b9dd38f146f1e6bf9a3d3866dea7c34c68ecb691",
+"sha512:643f694fa3f21077d42d1d3811732e7b7744c2db05e296dfd369dce90fa97c03f9a2c483b720bd91f85eb988b3b3c5ca02a023edee551cf9f2f3d9c988e3d685",
+]
+url = "http://repo.munts.com/alire/muntsos_raspberrypi3-9.1.0.tbz2"
+

--- a/index/mu/muntsos_raspberrypi4/muntsos_raspberrypi4-9.1.0.toml
+++ b/index/mu/muntsos_raspberrypi4/muntsos_raspberrypi4-9.1.0.toml
@@ -1,0 +1,33 @@
+name = "muntsos_raspberrypi4"
+description = "MuntsOS Embedded Linux support for RaspberryPi4 targets"
+tags = ["muntsos", "embedded", "linux", "arm64", "raspberrypi4"]
+version = "9.1.0"
+website = "https://github.com/pmunts/muntsos"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["aws.gpr", "libsimpleio.gpr"]
+
+[available."case(os)"]
+"linux" = true
+"..." = false
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+muntsos_dev_aarch64 = "*"
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch"]
+
+[origin]
+hashes = [
+"sha256:dce4b6063d46484a72cd4f0ca9da0779195cbc58ce095934af6c016898d3f772",
+"sha512:0f86d0a370283dc94d420997a7d73ced0fd70a98d79a3f28efeb2f4816f2a781674a82a4d352d9ae1420374974590bacadb52142b519781721f1da40a2a25c2a",
+]
+url = "http://repo.munts.com/alire/muntsos_raspberrypi4-9.1.0.tbz2"
+

--- a/index/mu/muntsos_raspberrypi5/muntsos_raspberrypi5-9.1.0.toml
+++ b/index/mu/muntsos_raspberrypi5/muntsos_raspberrypi5-9.1.0.toml
@@ -1,0 +1,33 @@
+name = "muntsos_raspberrypi5"
+description = "MuntsOS Embedded Linux support for RaspberryPi5 targets"
+tags = ["muntsos", "embedded", "linux", "arm64", "raspberrypi5"]
+version = "9.1.0"
+website = "https://github.com/pmunts/muntsos"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["aws.gpr", "libsimpleio.gpr"]
+
+[available."case(os)"]
+"linux" = true
+"..." = false
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+muntsos_dev_aarch64 = "*"
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch"]
+
+[origin]
+hashes = [
+"sha256:ceff29fe828d026f2eff340447c4a36579ef4d761e910215e36fe42f6f828bc7",
+"sha512:59b11e1db2336fc51b9330e3f18eb4e5803a8b6314d7d461b133f0c269e0070fc400a23daa333bb12195ec3a0191a5b47fd62026f0601b9df84870241f0a62c6",
+]
+url = "http://repo.munts.com/alire/muntsos_raspberrypi5-9.1.0.tbz2"
+


### PR DESCRIPTION
Incorporating:

muntsos_aarch64      release 9.1.0
muntsos_beaglebone   release 9.1.0
muntsos_raspberrypi1 release 9.1.0
muntsos_raspberrypi2 release 9.1.0
muntsos_raspberrypi3 release 9.1.0
muntsos_raspberrypi4 release 9.1.0
muntsos_raspberrypi5 release 9.1.0

Corrected invalid toolchain path wildcard for old Debian 11 / Crosstool-NG 1.25.0 / GCC 10.3.0 toolchains.

Reworked the post fetch action script to be much more robust.