### PR TITLE
Update excel_writer-18.0.0.toml - metadata (long description) change …

### DIFF
--- a/index/ex/excel_writer/excel_writer-18.0.0.toml
+++ b/index/ex/excel_writer/excel_writer-18.0.0.toml
@@ -27,8 +27,6 @@ Excel_Out is a standalone, portable Ada package for writing Excel spreadsheets w
 * Tests and demos included
 * Includes a CSV parser with related tools.
 * Free, open-source
-___
-(*) within limits of compiler's provided integer types and target architecture capacity.
 
 The creation of an Excel file is as simple as this small procedure:
 
@@ -48,6 +46,10 @@ begin
   xl.Close;
 end Small_Demo;
 ```
+
+___
+
+(*) within limits of compiler's provided integer types and target architecture capacity.
 """
 
 [origin]


### PR DESCRIPTION
…only

The footnote was not displayed correctly (some markdown->html converters seem to need more white space) + not well placed. Sorry for the trouble...