### PR TITLE
Update gwindows-1.4.2.toml

### DIFF
--- a/index/gw/gwindows/gwindows-1.4.2.toml
+++ b/index/gw/gwindows/gwindows-1.4.2.toml
@@ -62,6 +62,9 @@ website = "https://sourceforge.net/projects/gnavi/"
 windows = true
 '...' = false
 
+[environment.PATH]
+prepend = "${CRATE_ROOT}/alire/build/gnatcom/tools"
+
 [origin]
-commit = "407adc2e77bd3f3fc43522c5c73256495c29406d"
-url = "git+https://github.com/zertovitch/gwindows.git"
+url = "https://sourceforge.net/projects/gnavi/files/GWindows%20Archive%2013-Apr-2024%20%28Root%20Dir%20and%20Zip%202.0%29.zip"
+hashes = ["sha512:a13ac6e34ad5c278b5f8c341298edc748aa2ea0554fa38c3831765f2f58932fad373d583f76288a0e9acb9e1afa9463f85992a8d86ea7035e375125f77b035f3"]


### PR DESCRIPTION
Now that the GNAT setup is working, I am trying a version of the .toml two steps earlier in the previous PR.
- the gnatcom path is restored (not sure it is of any use, but it was put there by the first author of the .toml)
- Zip ball is used instead of Git (just for feeding the download statistics!)