### PR TITLE
hirtos 2.0.0

### DIFF
--- a/index/hi/hirtos/hirtos-2.0.0.toml
+++ b/index/hi/hirtos/hirtos-2.0.0.toml
@@ -31,6 +31,6 @@ command = ["alr", "build"]
 directory = "sample_apps/esp32_c3_hello"
 
 [origin]
-commit = "0c01280da07399a8a7fa8cb7980c3b7c3713801d"
+commit = "b091813c4123af30d6601ed70aea2b0dbbae55e5"
 url = "git+https://github.com/jgrivera67/HiRTOS.git"
 

--- a/index/hi/hirtos/hirtos-2.0.0.toml
+++ b/index/hi/hirtos/hirtos-2.0.0.toml
@@ -1,6 +1,11 @@
 #
-# NOTE: Before building for the first time with `alr build`, select the
-# corresponding cross compiler toolchain by running `alr toolchain --select`
+# Copyright (c) 2022-2024, German Rivera
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# NOTE: This crate is not meant to be built with the native compiler.
+# A dependency on a cross-compiler must be specified in the client
+# crate. See example client crates in the sample_apps folder.
 #
 name = "hirtos"
 description = "High-Integrity RTOS"
@@ -15,17 +20,17 @@ maintainers-logins = ["jgrivera67"]
 [configuration.variables]
 Platform = {type = "Enum", values = ["arm_fvp", "esp32_c3"], default = "arm_fvp"}
 
-[[depends-on]]
-gnat_arm_elf = "^13.2.1"
-#gnat_riscv64_elf = "^13.2.1"
-gnatprove = "^13.2.1"
+[[actions]]
+type = "test"
+command = ["alr", "build"]
+directory = "sample_apps/fvp_armv8r_aarch32_hello"
 
-[gpr-set-externals]
-CPU_Core = "arm_cortex_r52"
-#CPU_Core = "riscv32"
-
+[[actions]]
+type = "test"
+command = ["alr", "build"]
+directory = "sample_apps/esp32_c3_hello"
 
 [origin]
-commit = "63f7fdd2a01e061990a8921c64bb7966fad35e40"
+commit = "0c01280da07399a8a7fa8cb7980c3b7c3713801d"
 url = "git+https://github.com/jgrivera67/HiRTOS.git"
 

--- a/index/hi/hirtos/hirtos-2.0.0.toml
+++ b/index/hi/hirtos/hirtos-2.0.0.toml
@@ -31,6 +31,6 @@ command = ["alr", "build"]
 directory = "sample_apps/esp32_c3_hello"
 
 [origin]
-commit = "b091813c4123af30d6601ed70aea2b0dbbae55e5"
+commit = "ebcd8cb20115356aa0d99c97124e47a175e56e8e"
 url = "git+https://github.com/jgrivera67/HiRTOS.git"
 

--- a/index/hi/hirtos/hirtos-2.0.0.toml
+++ b/index/hi/hirtos/hirtos-2.0.0.toml
@@ -31,6 +31,6 @@ command = ["alr", "build"]
 directory = "sample_apps/esp32_c3_hello"
 
 [origin]
-commit = "ebcd8cb20115356aa0d99c97124e47a175e56e8e"
+commit = "66847740b093b19386959b0e7b65b0a09172a082"
 url = "git+https://github.com/jgrivera67/HiRTOS.git"
 

--- a/index/hi/hirtos/hirtos-2.0.0.toml
+++ b/index/hi/hirtos/hirtos-2.0.0.toml
@@ -1,0 +1,31 @@
+#
+# NOTE: Before building for the first time with `alr build`, select the
+# corresponding cross compiler toolchain by running `alr toolchain --select`
+#
+name = "hirtos"
+description = "High-Integrity RTOS"
+version = "2.0.0"
+licenses = "Apache-2.0"
+website = "https://github.com/jgrivera67/HiRTOS"
+tags = ["rtos"]
+authors = ["J. German Rivera"]
+maintainers = ["J. German Rivera <jgrivera67@gmail.com>"]
+maintainers-logins = ["jgrivera67"]
+
+[configuration.variables]
+Platform = {type = "Enum", values = ["arm_fvp", "esp32_c3"], default = "arm_fvp"}
+
+[[depends-on]]
+gnat_arm_elf = "^13.2.1"
+#gnat_riscv64_elf = "^13.2.1"
+gnatprove = "^13.2.1"
+
+[gpr-set-externals]
+CPU_Core = "arm_cortex_r52"
+#CPU_Core = "riscv32"
+
+
+[origin]
+commit = "63f7fdd2a01e061990a8921c64bb7966fad35e40"
+url = "git+https://github.com/jgrivera67/HiRTOS.git"
+


### PR DESCRIPTION
Created via `alr publish` with `alr 2.0.1`

Updated HiRTOS crate to version 2.0.0:
- Added RISC-V port for the ESP32-C3 platform
- Code refactoring to make other ports easier
