### PR TITLE
hirtos_separation_kernel 2.0.0

### DIFF
--- a/index/hi/hirtos_separation_kernel/hirtos_separation_kernel-2.0.0.toml
+++ b/index/hi/hirtos_separation_kernel/hirtos_separation_kernel-2.0.0.toml
@@ -28,7 +28,7 @@ directory = "../sample_apps/hello_partitions"
 
 
 [origin]
-commit = "b091813c4123af30d6601ed70aea2b0dbbae55e5"
+commit = "ebcd8cb20115356aa0d99c97124e47a175e56e8e"
 subdir = "./hirtos_separation_kernel/"
 url = "git+https://github.com/jgrivera67/HiRTOS.git"
 

--- a/index/hi/hirtos_separation_kernel/hirtos_separation_kernel-2.0.0.toml
+++ b/index/hi/hirtos_separation_kernel/hirtos_separation_kernel-2.0.0.toml
@@ -28,7 +28,7 @@ directory = "../sample_apps/hello_partitions"
 
 
 [origin]
-commit = "0c01280da07399a8a7fa8cb7980c3b7c3713801d"
+commit = "b091813c4123af30d6601ed70aea2b0dbbae55e5"
 subdir = "./hirtos_separation_kernel/"
 url = "git+https://github.com/jgrivera67/HiRTOS.git"
 

--- a/index/hi/hirtos_separation_kernel/hirtos_separation_kernel-2.0.0.toml
+++ b/index/hi/hirtos_separation_kernel/hirtos_separation_kernel-2.0.0.toml
@@ -1,6 +1,11 @@
 #
-# NOTE: Before building for the first time with `alr build`, select the
-# corresponding cross compiler toolchain by running `alr toolchain --select`
+# Copyright (c) 2022-2024, German Rivera
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# NOTE: This crate is not meant to be built with the native compiler.
+# A dependency on a cross-compiler must be specified in the client
+# crate. See example client crates in the sample_apps folder.
 #
 name = "hirtos_separation_kernel"
 description = "High-Integrity RTOS Separation Kernel"
@@ -16,18 +21,14 @@ maintainers-logins = ["jgrivera67"]
 Separation_Kernel_Debug_Tracing_On = {type = "Boolean", default = false}
 Platform = {type = "Enum", values = ["arm_fvp"], default = "arm_fvp"}
 
-[[depends-on]]
-gnat_arm_elf = "^13.2.1"
-#gnat_riscv64_elf = "^13.2.1"
-gnatprove = "^13.1.1"
-
-[gpr-set-externals]
-CPU_Core = "arm_cortex_r52"
-#CPU_Core = "riscv32"
+[[actions]]
+type = "test"
+command = ["alr", "build"]
+directory = "../sample_apps/hello_partitions"
 
 
 [origin]
-commit = "63f7fdd2a01e061990a8921c64bb7966fad35e40"
+commit = "0c01280da07399a8a7fa8cb7980c3b7c3713801d"
 subdir = "./hirtos_separation_kernel/"
 url = "git+https://github.com/jgrivera67/HiRTOS.git"
 

--- a/index/hi/hirtos_separation_kernel/hirtos_separation_kernel-2.0.0.toml
+++ b/index/hi/hirtos_separation_kernel/hirtos_separation_kernel-2.0.0.toml
@@ -1,0 +1,33 @@
+#
+# NOTE: Before building for the first time with `alr build`, select the
+# corresponding cross compiler toolchain by running `alr toolchain --select`
+#
+name = "hirtos_separation_kernel"
+description = "High-Integrity RTOS Separation Kernel"
+version = "2.0.0"
+licenses = "Apache-2.0"
+website = "https://github.com/jgrivera67/HiRTOS"
+tags = ["hypervisor"]
+authors = ["J. German Rivera"]
+maintainers = ["J. German Rivera <jgrivera67@gmail.com>"]
+maintainers-logins = ["jgrivera67"]
+
+[configuration.variables]
+Separation_Kernel_Debug_Tracing_On = {type = "Boolean", default = false}
+Platform = {type = "Enum", values = ["arm_fvp"], default = "arm_fvp"}
+
+[[depends-on]]
+gnat_arm_elf = "^13.2.1"
+#gnat_riscv64_elf = "^13.2.1"
+gnatprove = "^13.1.1"
+
+[gpr-set-externals]
+CPU_Core = "arm_cortex_r52"
+#CPU_Core = "riscv32"
+
+
+[origin]
+commit = "63f7fdd2a01e061990a8921c64bb7966fad35e40"
+subdir = "./hirtos_separation_kernel/"
+url = "git+https://github.com/jgrivera67/HiRTOS.git"
+


### PR DESCRIPTION
Created via `alr publish` with `alr 2.0.1`

Updated HiRTOS separation kernel crate to version 2.0.0:
- Bug fixes
- Code refactoring to make future ports easier

