### PR TITLE
remoteio release 2.22299.1

### DIFF
--- a/index/re/remoteio/remoteio-2.22299.1.toml
+++ b/index/re/remoteio/remoteio-2.22299.1.toml
@@ -1,0 +1,64 @@
+name = "remoteio"
+description = "Remote I/O Protocol Client Library for GNAT Ada"
+version = "2.22299.1"
+licenses = "BSD-1-Clause"
+website = "https://github.com/pmunts/libsimpleio"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["remoteio.gpr"]
+
+tags = ["embedded", "linux", "remoteio", "adc", "dac", "gpio", "i2c", "motor",
+"pwm", "sensor", "serial", "servo", "spi", "stepper"]
+
+[available."case(os)"]
+'linux|macos|windows' = true
+"..." = false
+
+# Linux needs libhidapi and libusb
+
+[[depends-on]]
+[depends-on."case(os)"."linux"]
+libhidapi = "*"
+
+[[depends-on]]
+[depends-on."case(os)"."linux"]
+libusb = "*"
+
+# macOS needs hidapi and libusb
+
+[[depends-on]]
+[depends-on."case(distribution)"."homebrew|macports"]
+libhidapi = "*"
+
+[[depends-on]]
+[depends-on."case(distribution)"."homebrew|macports"]
+libusb = "*"
+
+# On Linux, patch hid-hidapi.ads to link with libhidapi-hidraw.so
+
+[[actions."case(os)".linux]]
+type = "post-fetch"
+command = ["sh", "-c", "./src/scripts/postfetch.linux"]
+
+# On macOS, copy .dylib files to ./lib
+
+[[actions."case(os)".macos]]
+type = "post-fetch"
+command = ["sh", "-c", "./src/scripts/postfetch.macos"]
+
+# On Windows, copy .DLL files to ./lib
+
+[[actions."case(os)".windows]]
+type = "post-fetch"
+command = ["sh", "-c", "./src/scripts/postfetch.windows"]
+
+[origin]
+hashes = [
+"sha256:5992d783ceaac80916e5be6ee8d68b1460d872c5a56d06a26acdc9adc4e99b56",
+"sha512:06fbc80c72d5a6307767aee917426e6887cfdd738776361ba22c92945541075ec55e7f2624985850e4289217cccca7e5ccc4fc6cf27e6bbaa67edcf335d93a25",
+]
+url = "https://raw.githubusercontent.com/pmunts/alire-crates/dd543d3312c0004da554c49fc967088fad16b32b/remoteio/remoteio-2.22299.1.tbz2"
+


### PR DESCRIPTION
Rebuilt for alr 2.0, which broke previous post-fetch scripts.

Also moved the source archive repository
from http://repo.munts.com/alire
to   https://raw.githubusercontent.com/pmunts/alire-crates