### PR TITLE
Added support for CentOS/Fedora/RHEL

### DIFF
--- a/index/li/libhidapi/libhidapi-external.toml
+++ b/index/li/libhidapi/libhidapi-external.toml
@@ -8,6 +8,7 @@ maintainers-logins = ["pmunts"]
 [[external]]
 kind = "system"
 [external.origin."case(distribution)"]
+"centos|fedora|rhel" = ["hidapi-devel"]
 "debian|ubuntu" = ["libhidapi-dev"]
 arch = ["hidapi"]
 homebrew = ["hidapi"]

--- a/index/li/libusb/libusb-external.toml
+++ b/index/li/libusb/libusb-external.toml
@@ -8,6 +8,7 @@ maintainers-logins = ["pmunts"]
 [[external]]
 kind = "system"
 [external.origin."case(distribution)"]
+"centos|fedora|rhel" = ["libusb1-devel"]
 "debian|ubuntu" = ["libusb-1.0-0-dev"]
 arch = ["libusb"]
 homebrew = ["libusb"]


### PR DESCRIPTION
This should fix the build failures for `remoteio` and `mcp2221`.