### PR TITLE
muntsos_aarch64 release 9.3.0 Wed May  1 11:38:47 AM PDT 2024

### DIFF
--- a/index/mu/muntsos_aarch64/muntsos_aarch64-9.3.0.toml
+++ b/index/mu/muntsos_aarch64/muntsos_aarch64-9.3.0.toml
@@ -1,0 +1,33 @@
+name = "muntsos_aarch64"
+description = "MuntsOS Embedded Linux support for AArch64 targets"
+tags = ["muntsos", "embedded", "linux", "arm64", "aarch64"]
+version = "9.3.0"
+website = "https://github.com/pmunts/muntsos"
+
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+project-files = ["aws.gpr", "libsimpleio.gpr"]
+
+[available."case(os)"]
+"linux" = true
+"..." = false
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+muntsos_dev_aarch64 = "*"
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch"]
+
+[origin]
+hashes = [
+"sha256:2a0a0030397bf7ced41834dc2c49c9a267b2c6bd7522d7cdd9ce2208199d40e5",
+"sha512:9c52a827ddd755170ae2cca4e40b8ca21708532a3bc6792d243f8c394add3256e8c4843a982cc1d2353fe4694c00231c689cfe766c48a28914eb0269164ff22a",
+]
+url = "https://raw.githubusercontent.com/pmunts/alire-crates/a249340338e31d20a6ea8debdd9347ac26b078fb/muntsos_aarch64/muntsos_aarch64-9.3.0.tbz2"
+


### PR DESCRIPTION
Rebuilt for alr 2.0, which broke previous post-fetch scripts.

Also moved the source archive repository
from http://repo.munts.com/alire
to   https://raw.githubusercontent.com/pmunts/alire-crates