### PR TITLE
mcp2221 release 2.22357.1 Fri 17 May 2024 08:29:50 AM PDT

### DIFF
--- a/index/mc/mcp2221/mcp2221-2.22357.1.toml
+++ b/index/mc/mcp2221/mcp2221-2.22357.1.toml
@@ -1,0 +1,89 @@
+name = "mcp2221"
+version = "2.22357.1"
+description = "MCP2221 USB Raw HID I/O Expander Library for GNAT Ada"
+website = "https://github.com/pmunts/libsimpleio"
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+licenses = "BSD-1-Clause"
+
+long-description = """
+This crate contains a subset of the [**Linux Simple I/O
+Library**](https://github.com/pmunts/libsimpleio) Ada packages that are
+relevant for building programs for the MCP2221 USB Raw HID I/O expander.
+
+This crate can be built for Linux, MacOS, or Windows targets.
+
+The [MCP2221A](https://www.microchip.com/en-us/product/MCP2221A) is a
+[PIC16F1455](https://www.microchip.com/en-us/product/PIC16F1455)
+microcontroller that has been preprogrammed with firmware to implement
+*two* USB devices: a USB serial port and a raw HID device that acts as
+an I/O expander providing one
+[I](https://i2c.info/)[^2^](https://i2c.info/)[C](https://i2c.info/) bus
+controller (master only) and four
+[GPIO](https://en.wikipedia.org/wiki/General-purpose_input/output) pins
+(**`GP0`**, **`GP1`**, **`GP2`**, and **`GP3`**).
+
+The GPIO pins **`GP1`**, **`GP2`**, and **`GP3`** can be configured for
+some alternate functions, including 10-bit A/D inputs or 5-bit D/A
+outputs:
+
+**`GP1`**: **`GPIO ADC1`**\
+**`GP2`**: **`GPIO ADC2 DAC1`**\
+**`GP3`**: **`GPIO ADC3 DAC2`**
+
+The MCP2221A replaces an earlier part, the MCP2221. The only difference
+between the older MCP2221 and the newer MCP2221A is that the latter
+supports some higher baud rates on the USB serial port device. Since
+this crate only deals with the raw HID I/O expander functions, it will
+work fine with either the older MCP2221 or the newer MCP2221A.
+"""
+
+tags = ["embedded", "linux", "mcp2221", "adc", "dac", "gpio", "i2c", "motor",
+"pwm", "sensor", "serial", "servo", "spi", "stepper"]
+
+project-files = ["mcp2221.gpr"]
+
+[available."case(os)"]
+'linux|macos|windows' = true
+"..." = false
+
+# Linux needs libhidapi and libusb crates
+
+[[depends-on]]
+[depends-on."case(os)"."linux"]
+libhidapi = "*"
+
+[[depends-on]]
+[depends-on."case(os)"."linux"]
+libusb = "*"
+
+# macOS needs hidapi and libusb crates
+
+[[depends-on]]
+[depends-on."case(distribution)"."homebrew|macports"]
+libhidapi = "*"
+
+[[depends-on]]
+[depends-on."case(distribution)"."homebrew|macports"]
+libusb = "*"
+
+[[actions."case(os)".linux]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch.linux"]
+
+[[actions."case(os)".macos]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch.macos"]
+
+[[actions."case(os)".windows]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch.windows"]
+
+[origin]
+hashes = [
+"sha256:7acba0fa24337fae37c817acd2e63a752df5b7a95c242f954bbf5339b51982d9",
+"sha512:bf077e26c525f950e92f71303a44d001883a83bf02fefd1629f5af17e37fabbeb59acdcaedbab0a014b4ff6c10944588ab97209da2d35e55199a842e4acba567",
+]
+url = "https://raw.githubusercontent.com/pmunts/alire-crates/1884de293676770c7567193e566ec867deb4a43f/mcp2221/mcp2221-2.22357.1.tbz2"
+


### PR DESCRIPTION
Rebuilt for alr 2.0, which broke previous post-fetch scripts.

Also moved the source archive repository
from http://repo.munts.com/alire
to   https://raw.githubusercontent.com/pmunts/alire-crates

Also added long description.