### PR TITLE
Added external cmark library

### DIFF
--- a/index/li/libcmark/libcmark-external.toml
+++ b/index/li/libcmark/libcmark-external.toml
@@ -1,0 +1,13 @@
+description = "Cmark shared library"
+name = "libcmark"
+
+maintainers = ["AJ Ianozi <aj@ianozi.com>"]
+maintainers-logins = ["AJ-Ianozi"]
+
+[[external]]
+kind = "system"
+
+[external.origin.'case(distribution)']
+'debian|ubuntu' = ["libcmark-dev"]
+'arch|homebrew|macports|fedora|suse' = ["cmark"]
+'msys2' = ["mingw-w64-x86_64-cmark"]


### PR DESCRIPTION
This is mostly so I can publish [yass](https://github.com/yet-another-static-site-generator/yass) on alire, which requires the [libcmark](https://github.com/commonmark/cmark) external dependency.  It can also be used if others want to use libcmark too.