### PR TITLE
Update libmariadb Debian/Ubuntu package name

### DIFF
--- a/index/li/libmariadb/libmariadb-external.toml
+++ b/index/li/libmariadb/libmariadb-external.toml
@@ -7,7 +7,9 @@ maintainers-logins = ["stcarrez"]
 [[external]]
 kind = "system"
 [external.origin."case(distribution)"]
-"debian|ubuntu" = ["libmariadb-dev"]
+"debian|ubuntu" = ["libmariadb-dev",      # newer Debian versions
+                   "libmariadbclient-dev" # older Debian versions
+                   ]
 
 # No mariadb library on msys2
 [external.available.'case(os)']

--- a/index/li/libmariadb/libmariadb-external.toml
+++ b/index/li/libmariadb/libmariadb-external.toml
@@ -7,7 +7,7 @@ maintainers-logins = ["stcarrez"]
 [[external]]
 kind = "system"
 [external.origin."case(distribution)"]
-"debian|ubuntu" = ["libmariadbclient-dev"]
+"debian|ubuntu" = ["libmariadb-dev"]
 
 # No mariadb library on msys2
 [external.available.'case(os)']


### PR DESCRIPTION
The Debian package was renamed into libmariadb-dev.

With the old name, alr fails to find a solution and looks forever.