### PR TITLE
Apply label on missing dependencies from workflow

### DIFF
--- a/.github/workflows/build-distros.yml
+++ b/.github/workflows/build-distros.yml
@@ -18,6 +18,8 @@ jobs:
 
   build:
     name: ${{ matrix.tag }}
+    env:
+      JOB_NAME: ${{ matrix.tag }}
 
     runs-on: ubuntu-latest
 
@@ -67,4 +69,9 @@ jobs:
       with:
         image: ghcr.io/alire-project/docker/gnat:${{matrix.tag}}
         command: ${{env.CHECKS_REPO}}/scripts/gh-build-crate.sh
-        params: -v ${{ github.workspace }}/alire_install/bin/alr:/usr/bin/alr
+        params: >
+          -v ${{ github.workspace }}/alire_install/bin/alr:/usr/bin/alr
+          -v ${{ github.event_path}}:/etc/event.json
+          -e GITHUB_EVENT_PATH=/etc/event.json
+          -e GITHUB_REPOSITORY=${{ github.repository }}
+          -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-native-master.yml
+++ b/.github/workflows/build-native-master.yml
@@ -21,6 +21,8 @@ jobs:
 
   build:
     name: ${{ matrix.os }}
+    env:
+      JOB_NAME: ${{ matrix.os }}
 
     runs-on: ${{ matrix.os }}
 
@@ -61,3 +63,7 @@ jobs:
     - name: Test crate
       run: ${{env.CHECKS_REPO}}/scripts/gh-build-crate.sh
       shell: bash
+      env:
+        GITHUB_EVENT_PATH: ${{ github.event_path }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to apply labels/comment

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -18,6 +18,8 @@ jobs:
 
   build:
     name: ${{ matrix.os }}
+    env:
+      JOB_NAME: ${{ matrix.os }}
 
     runs-on: ${{ matrix.os }}
 
@@ -67,3 +69,7 @@ jobs:
     - name: Test crate
       run: ${{env.CHECKS_REPO}}/scripts/gh-build-crate.sh
       shell: bash
+      env:
+        GITHUB_EVENT_PATH: ${{ github.event_path }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to apply labels/comment

--- a/.github/workflows/build-ports.yml
+++ b/.github/workflows/build-ports.yml
@@ -20,6 +20,8 @@ jobs:
 
   build:
     name: ${{ matrix.os }}
+    env:
+      JOB_NAME: ${{ matrix.os }}
 
     runs-on: ${{ matrix.os }}
 
@@ -65,3 +67,7 @@ jobs:
     - name: Test crate
       run: ${{env.CHECKS_REPO}}/scripts/gh-build-crate.sh
       shell: bash
+      env:
+        GITHUB_EVENT_PATH: ${{ github.event_path }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to apply labels/comment

--- a/index/sa/saatana/saatana-2.0.2.toml
+++ b/index/sa/saatana/saatana-2.0.2.toml
@@ -11,7 +11,7 @@ project-files = ["saatana.gpr"]
 tags = ["cryptography", "spark"]
 
 [[depends-on]]
-gnat = "^2020"
+gnat = "^2020" # This is probably too restrictive
 
 [origin]
 url = "https://github.com/HeisenbugLtd/Saatana/archive/v2.0.2.tar.gz"


### PR DESCRIPTION
This should simplify review and raise awareness on crates that otherwise pass checks. Missing dependencies is not a merge blocker, but we should be able to detect if some wrong dependency is making the release unavailable in all platforms.