### PR TITLE
Diff helper via labels (II)

### DIFF
--- a/.github/workflows/diff-release.yml
+++ b/.github/workflows/diff-release.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: Check out alire-index
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
         # Needed to be able to diff and obtain changed files. Furthermore, we
@@ -54,3 +54,7 @@ jobs:
     - name: <<DIFF RELEASES>>
       run: ${{env.CHECKS_REPO}}/scripts/diff-release.sh || true # No deal breaker if failed
       shell: bash
+      env:
+        GITHUB_EVENT_PATH: ${{ github.event_path }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to apply labels/comment

--- a/index/li/libhello/libhello-1.0.1.toml
+++ b/index/li/libhello/libhello-1.0.1.toml
@@ -15,4 +15,4 @@ url = "git+https://github.com/alire-project/libhello.git"
 
 # We use this crate as a trigger to conveniently test minor changes to
 # metaprocesses of the CI of the repository itself.
-# Last touch: 2024-05-23 17:40 CET
+# Last touch: 2024-07-08 11:58 CET


### PR DESCRIPTION
Secrets are not passed to forks from outside the org, and GITHUB_TOKEN has read-only permissions in those cases, so there is no simple way around that. There is `pull_request_target` events but it is too convoluted for little gain.

So for now this changes nothing practically. Some kind of artifact consolidation could work instead. For another time.