### PR TITLE
lined 20240419.0.0

### DIFF
--- a/index/li/lined/lined-20240419.0.0.toml
+++ b/index/li/lined/lined-20240419.0.0.toml
@@ -1,0 +1,26 @@
+name = "lined"
+description = "Ada Implementation of the Line Editor from Software Tools"
+version = "20240419"
+
+authors = ["Jeff Carter"]
+maintainers = ["Bent Bracke <bent@bracke.dk>"]
+maintainers-logins = ["bracke"]
+licenses = "BSD-3-Clause"
+website = "https://github.com/bracke/Lined"
+tags = ["line", "editor"]
+
+executables = ["lined-program"]
+
+[build-switches]
+"*".style_checks = "No"
+
+[[depends-on]] # Avoid bug in GNAT 13
+gnat = "<13.0 | >=13.3"
+
+[[depends-on]]
+pragmarc = "^20240323.0.0"
+
+[origin]
+commit = "77c7046118adf0d2efd5c736755f4224faa40044"
+url = "git+https://github.com/bracke/Lined.git"
+


### PR DESCRIPTION
Created via `alr publish` with `alr 2.0.1`