### PR TITLE
Disable failing CI check pending diagnosis to avoid confusion

### DIFF
--- a/.github/workflows/build-native-master.yml
+++ b/.github/workflows/build-native-master.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-12
+          # - macos-12 # TODO: To be diagnosed
           - ubuntu-latest
           - windows-latest
 

--- a/index/li/libhello/libhello-1.0.1.toml
+++ b/index/li/libhello/libhello-1.0.1.toml
@@ -15,4 +15,4 @@ url = "git+https://github.com/alire-project/libhello.git"
 
 # We use this crate as a trigger to conveniently test minor changes to
 # metaprocesses of the CI of the repository itself.
-# Last touch: 2024-06-19 12:52 CET
+# Last touch: 2024-08-12 13:01 CET


### PR DESCRIPTION
This workflow is checking against Alire master branch, so it is not strictly mandatory at this time and may be confusing submitters.