### PR TITLE
Create gid-13.0.1.toml

### DIFF
--- a/index/gi/gid/gid-13.0.1.toml
+++ b/index/gi/gid/gid-13.0.1.toml
@@ -32,13 +32,15 @@ Animations (GIF, PNG) are supported.
 
 Some features:
 
+* *Fast*! Up to 2.8 times faster than ImageMagick.
 * Task safe
 * Endian-neutral
 * Multi-platform, but native code build
 * Standalone (no dependency on other libraires, bindings, etc.; no extra component needed for running)
 * Unconditionally portable code: OS-, CPU-, compiler- independent code (*).
 * Pure Ada 2012: this package can be used in projects in Ada 2012 and later versions of the Ada language
-* Free, open-source 
+* Test, demos and tools included.
+* *Free*, open-source 
 
 ______
 

--- a/index/gi/gid/gid-13.0.1.toml
+++ b/index/gi/gid/gid-13.0.1.toml
@@ -1,0 +1,53 @@
+description = "Generic Image Decoder - decode a broad variety of image formats"
+name = "gid"
+version = "13.0.1"
+authors = ["Gautier de Montmollin"]
+website = "https://gen-img-dec.sourceforge.io/"
+licenses = "MIT"
+maintainers = ["gdemont@hotmail.com"]
+maintainers-logins = ["zertovitch", "Fabien-Chouteau"]
+project-files = ["gid.gpr"]
+tags = ["image",
+  "animated", "animation",
+  "bitmap",
+  "color",
+  "decoder", "decoding", "decompress",
+  "digitization",
+  "lossless", "lossy",
+  "rbg",
+  "steganography",
+  "transparency", "transparent",
+  "bmp", "gif", "jpeg", "jpg", "pbm", "pgm", "png", "pnm", "ppm", "qoi", "tga", "targa"]
+executables = ["to_bmp"]
+long-description = """
+&nbsp;<img src="https://gen-img-dec.sourceforge.io/transp.png" alt="image" width="200" height="auto">
+
+The Generic Image Decoder (GID) is a low-level Ada package for decoding a broad variety of image formats,
+from any data stream, to any kind of medium, be it an in-memory bitmap, a GUI object, some other stream,
+floating-point data for scientific calculations, a browser element, a device, ...
+
+Currently supported formats are: BMP, GIF, JPEG, PNG, PNM (PBM, PGM, PPM), QOI, TGA
+
+Animations (GIF, PNG) are supported. 
+
+Some features:
+
+* Task safe
+* Endian-neutral
+* Multi-platform, but native code build
+* Standalone (no dependency on other libraires, bindings, etc.; no extra component needed for running)
+* Unconditionally portable code: OS-, CPU-, compiler- independent code (*).
+* Pure Ada 2012: this package can be used in projects in Ada 2012 and later versions of the Ada language
+* Free, open-source 
+
+______
+
+(*) within limits of compiler's provided integer types and target architecture capacity.
+"""
+
+[gpr-externals]
+GID_Build_Mode = ["Debug", "Fast_but_checked", "Fast_unchecked", "Small", "Smallest", "Profiling"]
+
+[origin]
+url = "https://sourceforge.net/projects/gen-img-dec/files/gid_013_01_without_test_images.zip"
+hashes = ["sha512:316514d234592629399fe2b3612ce6e4ff656e2792576aeee081e4b7024305b6e0d0bb5827eea832b4f4488eca2df40427e0a04068745272b6a58c3895f59d4c"]

--- a/index/gi/gid/gid-13.0.1.toml
+++ b/index/gi/gid/gid-13.0.1.toml
@@ -39,7 +39,7 @@ Some features:
 * Standalone (no dependency on other libraires, bindings, etc.; no extra component needed for running)
 * Unconditionally portable code: OS-, CPU-, compiler- independent code (*).
 * Pure Ada 2012: this package can be used in projects in Ada 2012 and later versions of the Ada language
-* Test, demos and tools included.
+* Tests, demos and tools included.
 * *Free*, open-source 
 
 ______


### PR DESCRIPTION
The library is unchanged, but the demo/tools output now to PNG instead of the unknown PPM.