### PR TITLE
Fedora only includes end user runtime not headers in cmark

### DIFF
--- a/index/li/libcmark/libcmark-external.toml
+++ b/index/li/libcmark/libcmark-external.toml
@@ -9,5 +9,6 @@ kind = "system"
 
 [external.origin.'case(distribution)']
 'debian|ubuntu' = ["libcmark-dev"]
-'arch|homebrew|macports|fedora|suse' = ["cmark"]
+'arch|homebrew|macports|suse' = ["cmark"]
+'fedora' = ["cmark-devel"]
 'msys2' = ["mingw-w64-x86_64-cmark"]


### PR DESCRIPTION
This should fix an issue with cmark library on fedora.