### PR TITLE
Add Ada Utility Library AWS support for 2.6.0

### DIFF
--- a/index/ut/utilada_aws/utilada_aws-2.6.0.toml
+++ b/index/ut/utilada_aws/utilada_aws-2.6.0.toml
@@ -1,0 +1,32 @@
+description = "Utility Library REST support on top of AWS"
+long-description = "\n[![Build Status](https://img.shields.io/jenkins/s/https/jenkins.vacs.fr/Ada-Util.svg)](https://jenkins.vacs.fr/job/Ada-Util/)\n[![Test Status](https://img.shields.io/jenkins/t/https/jenkins.vacs.fr/Ada-Util.svg)](https://jenkins.vacs.fr/job/Ada-Util/)\n[![codecov](https://codecov.io/gh/stcarrez/ada-util/branch/master/graph/badge.svg)](https://codecov.io/gh/stcarrez/ada-util)\n\n\nThis small library provides an HTTP backend on top of AWS.\nIt is can be used by the `Util.Http` package.\n\nAn alternate HTTP backend is provided by CURL with utilada_curl.\n\n"
+name = "utilada_aws"
+version = "2.6.0"
+authors = ["Stephane.Carrez@gmail.com"]
+licenses = "Apache-2.0"
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+project-files = [".alire/aws/utilada_aws.gpr"]
+tags = ["web", "http"]
+website = "https://gitlab.com/stcarrez/ada-util"
+
+[[depends-on]]
+utilada = "^2.6.0"
+aws = "^23.0"
+
+[gpr-externals]
+BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
+UTIL_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+UTIL_AWS_IMPL = ["1", "2", "3"]
+
+[gpr-set-externals]
+UTIL_AWS_IMPL = "3"
+
+[configuration]
+disabled = true
+
+[origin]
+commit = "99ca46a12f0d542348262d67b613d58f0d14c7b5"
+subdir = "./.alire/aws/"
+url = "git+https://gitlab.com/stcarrez/ada-util.git"
+

--- a/index/ut/utilada_aws/utilada_aws-2.6.0.toml
+++ b/index/ut/utilada_aws/utilada_aws-2.6.0.toml
@@ -6,7 +6,7 @@ authors = ["Stephane.Carrez@gmail.com"]
 licenses = "Apache-2.0"
 maintainers = ["Stephane.Carrez@gmail.com"]
 maintainers-logins = ["stcarrez"]
-project-files = [".alire/aws/utilada_aws.gpr"]
+project-files = ["utilada_aws.gpr"]
 tags = ["web", "http"]
 website = "https://gitlab.com/stcarrez/ada-util"
 

--- a/index/ut/utilada_aws/utilada_aws-2.6.0.toml
+++ b/index/ut/utilada_aws/utilada_aws-2.6.0.toml
@@ -12,15 +12,12 @@ website = "https://gitlab.com/stcarrez/ada-util"
 
 [available.'case(os)']
 linux = true
-freebsd = true
 windows = false
 macos = false
 '...' = false
 
 [[depends-on]]
 utilada = "^2.6.0"
-
-[depends-on.'case(os)'.'...']
 aws = "^24.0.0"
 xmlada = "^24.0.0"
 gnatcoll = "^24.0.0"

--- a/index/ut/utilada_aws/utilada_aws-2.6.0.toml
+++ b/index/ut/utilada_aws/utilada_aws-2.6.0.toml
@@ -12,7 +12,18 @@ website = "https://gitlab.com/stcarrez/ada-util"
 
 [[depends-on]]
 utilada = "^2.6.0"
-aws = "^23.0"
+
+# See https://github.com/AdaCore/aws/issues/380
+# and https://github.com/alire-project/alire/issues/1710
+[depends-on.'case(os)'.windows]
+aws = "^23.0.0"
+xmlada = "^23.0.0"
+gnatcoll = "^23.0.0"
+
+[depends-on.'case(os)'.'...']
+aws = "^24.0.0"
+xmlada = "^24.0.0"
+gnatcoll = "^24.0.0"
 
 [gpr-externals]
 BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]

--- a/index/ut/utilada_aws/utilada_aws-2.6.0.toml
+++ b/index/ut/utilada_aws/utilada_aws-2.6.0.toml
@@ -10,15 +10,15 @@ project-files = [".alire/aws/utilada_aws.gpr"]
 tags = ["web", "http"]
 website = "https://gitlab.com/stcarrez/ada-util"
 
+[available.'case(os)']
+linux = true
+freebsd = true
+windows = false
+macos = false
+'...' = false
+
 [[depends-on]]
 utilada = "^2.6.0"
-
-# See https://github.com/AdaCore/aws/issues/380
-# and https://github.com/alire-project/alire/issues/1710
-[depends-on.'case(os)'.windows]
-aws = "^23.0.0"
-xmlada = "^23.0.0"
-gnatcoll = "^23.0.0"
 
 [depends-on.'case(os)'.'...']
 aws = "^24.0.0"


### PR DESCRIPTION
This is an old version of Ada Utility Library but the AWS part was not submitted due to problems with AWS. Hopefully, this should work with AWS 23.0.