### PR TITLE
a0b_i2c 0.1.0

### DIFF
--- a/index/a0/a0b_i2c/a0b_i2c-0.1.0.toml
+++ b/index/a0/a0b_i2c/a0b_i2c-0.1.0.toml
@@ -1,0 +1,28 @@
+name = "a0b_i2c"
+description = "A0B I2C API"
+version = "0.1.0"
+
+authors = ["Vadim Godunko"]
+maintainers = ["Vadim Godunko <vgodunko@gmail.com>"]
+maintainers-logins = ["godunko"]
+licenses = "Apache-2.0 WITH LLVM-exception"
+tags = ["a0b", "embedded", "i2c"]
+
+project-files = ["gnat/a0b_i2c.gpr"]
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+a0b_base = "*"
+a0b_callbacks = "*"
+
+[[actions]]
+type = "test"
+directory = "selftest"
+command = ["alr", "build"]
+
+[origin]
+commit = "67a3e9f5443bdaf500ce46beab1414c73ea4ed8e"
+url = "git+https://github.com/godunko/a0b-i2c.git"
+


### PR DESCRIPTION
Created via `alr publish` with `alr 2.0.2+9b80158`