### PR TITLE
a0b_time 0.2.0

### DIFF
--- a/index/a0/a0b_time/a0b_time-0.2.0.toml
+++ b/index/a0/a0b_time/a0b_time-0.2.0.toml
@@ -1,0 +1,28 @@
+name = "a0b_time"
+description = "A0B Monotonic Time"
+version = "0.2.0"
+
+authors = ["Vadim Godunko"]
+maintainers = ["Vadim Godunko <vgodunko@gmail.com>"]
+maintainers-logins = ["godunko"]
+licenses = "Apache-2.0 WITH LLVM-exception"
+tags = ["a0b", "embedded", "time"]
+
+project-files = ["gnat/a0b_time.gpr"]
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+a0b_base = "*"
+a0b_time_platform = "0.1.0"
+
+[[actions]]
+type = "test"
+directory = "selftest"
+command = ["alr", "build"]
+
+[origin]
+commit = "fe82dcefa0416c4dce8d0b7ce71f9b04419d2fb5"
+url = "git+https://github.com/godunko/a0b-time.git"
+


### PR DESCRIPTION
Created via `alr publish` with `alr 2.0.2+9b80158`