### PR TITLE
Update libgtk3-external.toml with suse lib name

### DIFF
--- a/index/li/libgtk3/libgtk3-external.toml
+++ b/index/li/libgtk3/libgtk3-external.toml
@@ -9,6 +9,7 @@ kind = "system"
 [external.origin."case(distribution)"]
 "debian|ubuntu" = ["libgtk-3-dev"]
 "centos|fedora" = ["gtk3-devel"]
+suse = ["gtk3-devel"]
 arch = ["gtk3"]
 msys2 = ["mingw-w64-x86_64-gtk3"]
 homebrew = ["gtk+3"]


### PR DESCRIPTION
opensuse also uses gtk3-devel.


```
$ zypper info gtk3-devel
Loading repository data...
Reading installed packages...


Information for package gtk3-devel:
-----------------------------------
Repository     : Main Repository (OSS) (20241025)
Name           : gtk3-devel
Version        : 3.24.43-3.1
Arch           : x86_64
Vendor         : openSUSE
Installed Size : 16.9 MiB
```

...