### PR TITLE
hp41cx_tools 1.6.0

### DIFF
--- a/index/hp/hp41cx_tools/hp41cx_tools-1.6.0.toml
+++ b/index/hp/hp41cx_tools/hp41cx_tools-1.6.0.toml
@@ -1,0 +1,49 @@
+name                        = "hp41cx_tools"
+description                 = "HP-41CX emulator Tools"
+long-description            = """Tools for manipulating memory dumps from HP-41CX emulators.
+
+The following HP-41CX emulators are supported:
+
+* [PX-41CX](https://paxer.net/PX-41CX/) from Paxer.
+* [DM41X](https://www.swissmicros.com/product/dm41x) from SwissMicros.
+
+Currently hex dump files can be decoded to user readable files.
+"""
+version                     = "1.6.0"
+
+licenses                    = "GPL-3.0-or-later"
+authors                     = ["Martin Krischik <krischik@users.sourceforge.net>"]
+maintainers                 = ["Martin Krischik <krischik@users.sourceforge.net>"]
+maintainers-logins          = ["krischik"]
+executables                 = ["hp41cx_tools-main"]
+website                     = "https://calculator-scripts.sourceforge.io/px-41cx"
+tags                        = ["calculator", "tools", "retrocomputing", "ada-2022", "hp-41cx", "dm41x", "px41cx"]
+
+[build-switches]
+development.runtime_checks  = "Overflow"
+release.runtime_checks      = "Default"
+validation.runtime_checks   = "Everything"
+development.contracts       = "Yes"
+release.contracts           = "No"
+validation.contracts        = "Yes"
+
+[[depends-on]]
+adacl                       = "5.16.0"
+gnat_native                 = "^14.2"
+
+[[actions]]
+type                        = "test"
+command                     = ["alr", "run"]
+directory                   = "test"
+
+# vim: set textwidth=0 nowrap tabstop=8 shiftwidth=4 softtabstop=4 expandtab :
+# vim: set filetype=toml fileencoding=utf-8 fileformat=unix foldmethod=diff :
+# vim: set spell spelllang=en_gb :
+
+[origin]
+hashes = [
+"sha256:7337189c4829a1492c05200a630e6e35d1566e5ddcb1a4ca5a395ac04f13d368",
+"sha512:1974bf1138e1219c5d75340174b00960d71d1ed9cd9f28f0b72e850d2a44ceb58bc3872f481abfbb98c2bfd544c66225bd90349d22327c453ed924e90eaeec69",
+]
+url = "https://sourceforge.net/projects/calculator-scripts/files/Alire/hp41cx_tools-1.6.0.tgz"
+


### PR DESCRIPTION
Created via `alr publish` with `alr 2.0.2+9b80158`

Tools for converting memory dumps from HP-41CX emulators.

The following HP-41CX emulators are supported:

* [PX-41CX](https://paxer.net/PX-41CX/) from Paxer.
* [DM41X](https://www.swissmicros.com/product/dm41x) from SwissMicros.

Currently hex dump files can be decoded to user readable files.