### PR TITLE
Add "mingw-w64-x86_64-angleproject" to properly retrieve system EGL libs

### DIFF
--- a/index/li/libegl/libegl-external.toml
+++ b/index/li/libegl/libegl-external.toml
@@ -13,4 +13,4 @@ kind = "system"
 [external.origin.'case(distribution)']
 'debian|ubuntu' = ["libegl-dev"]
 arch            = ["libglvnd"]
-msys2           = ["mingw-w64-x86_64-mesa"]
+msys2           = ["mingw-w64-x86_64-mesa", "mingw-w64-x86_64-angleproject"]


### PR DESCRIPTION
@onox, @charlie5 

I tested this on Windows, and as it stands, the `mingw-w64-x86_64-mesa` package does not provide the necessary EGL libraries, so linking fails. To resolve this, I had to install the `mingw-w64-x86_64-angleproject` package, which includes `libEGL` and related libraries. Could you confirm if there was another intended way to provide these libraries?

@mosteo I manually added the following entry:

```toml
msys2 = ["mingw-w64-x86_64-mesa", "mingw-w64-x86_64-angleproject"]
```

to `C:\Users\olivi\AppData\Local\alire\settings\indexes\community\repo\index\li\libegl\libegl-external.toml`, but it didn’t trigger the installation of `mingw-w64-x86_64-angleproject` (running `alr update` had no effect). I had to install it manually using the MSYS2 console. 

Because of this, I’m unsure if my proposed changes are the correct way to address the issue or if there’s a different intended process for triggering the installation locally.

Thank you,  
Olivier