### PR TITLE
nrf52-runtimes 14.1.0

### DIFF
--- a/index/em/embedded_nrf52832/embedded_nrf52832-14.1.0.toml
+++ b/index/em/embedded_nrf52832/embedded_nrf52832-14.1.0.toml
@@ -1,0 +1,56 @@
+name = "embedded_nrf52832"
+description = "embedded runtime for the nRF52832 SoC"
+version = "14.1.0"
+
+long-description = """
+## Usage
+
+First edit your `alire.toml` file and add the following elements:
+ - Add `embedded_nrf52832` in the dependency list:
+   ```toml
+   [[depends-on]]
+   embedded_nrf52832 = "*"
+   ```
+
+Then edit your project file to add the following elements:
+ - "with" the run-time project file. With this, gprbuild will compile the run-time before your application
+   ```ada
+   with "runtime_build.gpr";
+   ```
+ - Specify the `Target` and `Runtime` attributes:
+   ```ada
+      for Target use runtime_build'Target;
+      for Runtime ("Ada") use runtime_build'Runtime ("Ada");
+   ```
+"""
+
+authors = ["AdaCore", "Daniel King"]
+maintainers = ["Daniel King <damaki.gh@gmail.com>"]
+maintainers-logins = ["damaki"]
+licenses = "GPL-3.0-or-later WITH GCC-exception-3.1"
+tags = ["embedded", "runtime"]
+website = "https://github.com/damaki/nrf52-runtimes"
+
+project-files = ['runtime_build.gpr', 'ravenscar_build.gpr']
+
+[configuration]
+generate_gpr = false
+generate_c = false
+output_dir = "gnat_user"
+
+[configuration.variables]
+Time_Base = { type = "Enum", values = ["RTC0", "RTC1", "RTC2"], default = "RTC2" }
+LFCLK_Src = { type = "Enum", values = ["Xtal", "RC", "Synth"], default = "Xtal" }
+Use_SWO_Trace = { type = "Boolean", default = true }
+Use_Reset_Pin = { type = "Boolean", default = true }
+
+[[depends-on]]
+gnat_arm_elf = "^14"
+
+[origin]
+hashes = [
+"sha256:50faca4dc127ac601ca8f6c4340ef07c48ca9e839ea25244489c39193ea163aa",
+"sha512:30c3c6723fdc3f2cfa2850c30c1cc3950abf16b85b6e4f35409eb72ff01c11b289cecfcd62a9ee0f1a9136253d36594842e549d157088aefb42a6c054c91917a",
+]
+url = "https://github.com/damaki/nrf52-runtimes/releases/download/v14.1.0/embedded-nrf52832-14.1.0.tar.gz"
+

--- a/index/em/embedded_nrf52833/embedded_nrf52833-14.1.0.toml
+++ b/index/em/embedded_nrf52833/embedded_nrf52833-14.1.0.toml
@@ -1,0 +1,56 @@
+name = "embedded_nrf52833"
+description = "embedded runtime for the nRF52833 SoC"
+version = "14.1.0"
+
+long-description = """
+## Usage
+
+First edit your `alire.toml` file and add the following elements:
+ - Add `embedded_nrf52833` in the dependency list:
+   ```toml
+   [[depends-on]]
+   embedded_nrf52833 = "*"
+   ```
+
+Then edit your project file to add the following elements:
+ - "with" the run-time project file. With this, gprbuild will compile the run-time before your application
+   ```ada
+   with "runtime_build.gpr";
+   ```
+ - Specify the `Target` and `Runtime` attributes:
+   ```ada
+      for Target use runtime_build'Target;
+      for Runtime ("Ada") use runtime_build'Runtime ("Ada");
+   ```
+"""
+
+authors = ["AdaCore", "Daniel King"]
+maintainers = ["Daniel King <damaki.gh@gmail.com>"]
+maintainers-logins = ["damaki"]
+licenses = "GPL-3.0-or-later WITH GCC-exception-3.1"
+tags = ["embedded", "runtime"]
+website = "https://github.com/damaki/nrf52-runtimes"
+
+project-files = ['runtime_build.gpr', 'ravenscar_build.gpr']
+
+[configuration]
+generate_gpr = false
+generate_c = false
+output_dir = "gnat_user"
+
+[configuration.variables]
+Time_Base = { type = "Enum", values = ["RTC0", "RTC1", "RTC2"], default = "RTC2" }
+LFCLK_Src = { type = "Enum", values = ["Xtal", "RC", "Synth"], default = "Xtal" }
+Use_SWO_Trace = { type = "Boolean", default = true }
+Use_Reset_Pin = { type = "Boolean", default = true }
+
+[[depends-on]]
+gnat_arm_elf = "^14"
+
+[origin]
+hashes = [
+"sha256:b6606ac64e71de87df04fdc1c3d59a382b73c0983c37dd09a79fe9d6cc3dacb2",
+"sha512:d64aa7673b171537d0dace105048d3845a960d0ac9d22ed1f8b4fcec58634376bf53fbf3961f6435fa6e640b58ea4b371bf2f8da714490ef3e6f773180f0f82c",
+]
+url = "https://github.com/damaki/nrf52-runtimes/releases/download/v14.1.0/embedded-nrf52833-14.1.0.tar.gz"
+

--- a/index/em/embedded_nrf52840/embedded_nrf52840-14.1.0.toml
+++ b/index/em/embedded_nrf52840/embedded_nrf52840-14.1.0.toml
@@ -1,0 +1,56 @@
+name = "embedded_nrf52840"
+description = "embedded runtime for the nRF52840 SoC"
+version = "14.1.0"
+
+long-description = """
+## Usage
+
+First edit your `alire.toml` file and add the following elements:
+ - Add `embedded_nrf52840` in the dependency list:
+   ```toml
+   [[depends-on]]
+   embedded_nrf52840 = "*"
+   ```
+
+Then edit your project file to add the following elements:
+ - "with" the run-time project file. With this, gprbuild will compile the run-time before your application
+   ```ada
+   with "runtime_build.gpr";
+   ```
+ - Specify the `Target` and `Runtime` attributes:
+   ```ada
+      for Target use runtime_build'Target;
+      for Runtime ("Ada") use runtime_build'Runtime ("Ada");
+   ```
+"""
+
+authors = ["AdaCore", "Daniel King"]
+maintainers = ["Daniel King <damaki.gh@gmail.com>"]
+maintainers-logins = ["damaki"]
+licenses = "GPL-3.0-or-later WITH GCC-exception-3.1"
+tags = ["embedded", "runtime"]
+website = "https://github.com/damaki/nrf52-runtimes"
+
+project-files = ['runtime_build.gpr', 'ravenscar_build.gpr']
+
+[configuration]
+generate_gpr = false
+generate_c = false
+output_dir = "gnat_user"
+
+[configuration.variables]
+Time_Base = { type = "Enum", values = ["RTC0", "RTC1", "RTC2"], default = "RTC2" }
+LFCLK_Src = { type = "Enum", values = ["Xtal", "RC", "Synth"], default = "Xtal" }
+Use_SWO_Trace = { type = "Boolean", default = true }
+Use_Reset_Pin = { type = "Boolean", default = true }
+
+[[depends-on]]
+gnat_arm_elf = "^14"
+
+[origin]
+hashes = [
+"sha256:d2b55469dd3e3945164ad671524c066f4286b496b39663a79b45a3d3cdf85977",
+"sha512:d3e0d9df65d18b9c496ef34669d306ad73164cf8d145eefaa89931dc0ab0efd0135db993d049e117d16c54857fdb5600bcd31f1536c2dc260a6f6be2ff8e2a57",
+]
+url = "https://github.com/damaki/nrf52-runtimes/releases/download/v14.1.0/embedded-nrf52840-14.1.0.tar.gz"
+

--- a/index/li/light_nrf52832/light_nrf52832-14.1.0.toml
+++ b/index/li/light_nrf52832/light_nrf52832-14.1.0.toml
@@ -1,0 +1,56 @@
+name = "light_nrf52832"
+description = "light runtime for the nRF52832 SoC"
+version = "14.1.0"
+
+long-description = """
+## Usage
+
+First edit your `alire.toml` file and add the following elements:
+ - Add `light_nrf52832` in the dependency list:
+   ```toml
+   [[depends-on]]
+   light_nrf52832 = "*"
+   ```
+
+Then edit your project file to add the following elements:
+ - "with" the run-time project file. With this, gprbuild will compile the run-time before your application
+   ```ada
+   with "runtime_build.gpr";
+   ```
+ - Specify the `Target` and `Runtime` attributes:
+   ```ada
+      for Target use runtime_build'Target;
+      for Runtime ("Ada") use runtime_build'Runtime ("Ada");
+   ```
+"""
+
+authors = ["AdaCore", "Daniel King"]
+maintainers = ["Daniel King <damaki.gh@gmail.com>"]
+maintainers-logins = ["damaki"]
+licenses = "GPL-3.0-or-later WITH GCC-exception-3.1"
+tags = ["embedded", "runtime"]
+website = "https://github.com/damaki/nrf52-runtimes"
+
+project-files = ['runtime_build.gpr']
+
+[configuration]
+generate_gpr = false
+generate_c = false
+output_dir = "gnat_user"
+
+[configuration.variables]
+Time_Base = { type = "Enum", values = ["RTC0", "RTC1", "RTC2"], default = "RTC2" }
+LFCLK_Src = { type = "Enum", values = ["Xtal", "RC", "Synth"], default = "Xtal" }
+Use_SWO_Trace = { type = "Boolean", default = true }
+Use_Reset_Pin = { type = "Boolean", default = true }
+
+[[depends-on]]
+gnat_arm_elf = "^14"
+
+[origin]
+hashes = [
+"sha256:4dee01ccce68ba7bb26755e2bafaf3c112e55c6248077de14af33d3c1566185c",
+"sha512:5fa4b4bff1b9326007749c2db754845a09060458c7312f6891a8520273f9d9bbff546c3640fd9d53fdf5e892d4271fa23ad8d65df98ee9f77d16a5e60f3244d0",
+]
+url = "https://github.com/damaki/nrf52-runtimes/releases/download/v14.1.0/light-nrf52832-14.1.0.tar.gz"
+

--- a/index/li/light_nrf52833/light_nrf52833-14.1.0.toml
+++ b/index/li/light_nrf52833/light_nrf52833-14.1.0.toml
@@ -1,0 +1,56 @@
+name = "light_nrf52833"
+description = "light runtime for the nRF52833 SoC"
+version = "14.1.0"
+
+long-description = """
+## Usage
+
+First edit your `alire.toml` file and add the following elements:
+ - Add `light_nrf52833` in the dependency list:
+   ```toml
+   [[depends-on]]
+   light_nrf52833 = "*"
+   ```
+
+Then edit your project file to add the following elements:
+ - "with" the run-time project file. With this, gprbuild will compile the run-time before your application
+   ```ada
+   with "runtime_build.gpr";
+   ```
+ - Specify the `Target` and `Runtime` attributes:
+   ```ada
+      for Target use runtime_build'Target;
+      for Runtime ("Ada") use runtime_build'Runtime ("Ada");
+   ```
+"""
+
+authors = ["AdaCore", "Daniel King"]
+maintainers = ["Daniel King <damaki.gh@gmail.com>"]
+maintainers-logins = ["damaki"]
+licenses = "GPL-3.0-or-later WITH GCC-exception-3.1"
+tags = ["embedded", "runtime"]
+website = "https://github.com/damaki/nrf52-runtimes"
+
+project-files = ['runtime_build.gpr']
+
+[configuration]
+generate_gpr = false
+generate_c = false
+output_dir = "gnat_user"
+
+[configuration.variables]
+Time_Base = { type = "Enum", values = ["RTC0", "RTC1", "RTC2"], default = "RTC2" }
+LFCLK_Src = { type = "Enum", values = ["Xtal", "RC", "Synth"], default = "Xtal" }
+Use_SWO_Trace = { type = "Boolean", default = true }
+Use_Reset_Pin = { type = "Boolean", default = true }
+
+[[depends-on]]
+gnat_arm_elf = "^14"
+
+[origin]
+hashes = [
+"sha256:e18f3f6c6defd146b67f7ad253ab1f7d2393080424462f3692678d8b556e138f",
+"sha512:58fe907354f0c2929c96e3b78b7c0d7ba974eace805cfdfd7fdbf940dfabbf5a128d118ceefc720810703b1ac0e283150f08e021ae3c1d9ba6a2cee154261200",
+]
+url = "https://github.com/damaki/nrf52-runtimes/releases/download/v14.1.0/light-nrf52833-14.1.0.tar.gz"
+

--- a/index/li/light_nrf52840/light_nrf52840-14.1.0.toml
+++ b/index/li/light_nrf52840/light_nrf52840-14.1.0.toml
@@ -1,0 +1,56 @@
+name = "light_nrf52840"
+description = "light runtime for the nRF52840 SoC"
+version = "14.1.0"
+
+long-description = """
+## Usage
+
+First edit your `alire.toml` file and add the following elements:
+ - Add `light_nrf52840` in the dependency list:
+   ```toml
+   [[depends-on]]
+   light_nrf52840 = "*"
+   ```
+
+Then edit your project file to add the following elements:
+ - "with" the run-time project file. With this, gprbuild will compile the run-time before your application
+   ```ada
+   with "runtime_build.gpr";
+   ```
+ - Specify the `Target` and `Runtime` attributes:
+   ```ada
+      for Target use runtime_build'Target;
+      for Runtime ("Ada") use runtime_build'Runtime ("Ada");
+   ```
+"""
+
+authors = ["AdaCore", "Daniel King"]
+maintainers = ["Daniel King <damaki.gh@gmail.com>"]
+maintainers-logins = ["damaki"]
+licenses = "GPL-3.0-or-later WITH GCC-exception-3.1"
+tags = ["embedded", "runtime"]
+website = "https://github.com/damaki/nrf52-runtimes"
+
+project-files = ['runtime_build.gpr']
+
+[configuration]
+generate_gpr = false
+generate_c = false
+output_dir = "gnat_user"
+
+[configuration.variables]
+Time_Base = { type = "Enum", values = ["RTC0", "RTC1", "RTC2"], default = "RTC2" }
+LFCLK_Src = { type = "Enum", values = ["Xtal", "RC", "Synth"], default = "Xtal" }
+Use_SWO_Trace = { type = "Boolean", default = true }
+Use_Reset_Pin = { type = "Boolean", default = true }
+
+[[depends-on]]
+gnat_arm_elf = "^14"
+
+[origin]
+hashes = [
+"sha256:176f9a986d560bd2b1a97de7780814f46e5d014efefc22988b8d8e27fe277722",
+"sha512:a2a7e519a7bddddbdad9242891bb03b35d225fc4a26ab438dccd29f163ac92aabc1fca9a7aaf04b1e4f67f0bac0ba821de19f54ed0831acaa125c8ab4f87d6f9",
+]
+url = "https://github.com/damaki/nrf52-runtimes/releases/download/v14.1.0/light-nrf52840-14.1.0.tar.gz"
+

--- a/index/li/light_tasking_nrf52832/light_tasking_nrf52832-14.1.0.toml
+++ b/index/li/light_tasking_nrf52832/light_tasking_nrf52832-14.1.0.toml
@@ -1,0 +1,56 @@
+name = "light_tasking_nrf52832"
+description = "light-tasking runtime for the nRF52832 SoC"
+version = "14.1.0"
+
+long-description = """
+## Usage
+
+First edit your `alire.toml` file and add the following elements:
+ - Add `light_tasking_nrf52832` in the dependency list:
+   ```toml
+   [[depends-on]]
+   light_tasking_nrf52832 = "*"
+   ```
+
+Then edit your project file to add the following elements:
+ - "with" the run-time project file. With this, gprbuild will compile the run-time before your application
+   ```ada
+   with "runtime_build.gpr";
+   ```
+ - Specify the `Target` and `Runtime` attributes:
+   ```ada
+      for Target use runtime_build'Target;
+      for Runtime ("Ada") use runtime_build'Runtime ("Ada");
+   ```
+"""
+
+authors = ["AdaCore", "Daniel King"]
+maintainers = ["Daniel King <damaki.gh@gmail.com>"]
+maintainers-logins = ["damaki"]
+licenses = "GPL-3.0-or-later WITH GCC-exception-3.1"
+tags = ["embedded", "runtime"]
+website = "https://github.com/damaki/nrf52-runtimes"
+
+project-files = ['runtime_build.gpr', 'ravenscar_build.gpr']
+
+[configuration]
+generate_gpr = false
+generate_c = false
+output_dir = "gnat_user"
+
+[configuration.variables]
+Time_Base = { type = "Enum", values = ["RTC0", "RTC1", "RTC2"], default = "RTC2" }
+LFCLK_Src = { type = "Enum", values = ["Xtal", "RC", "Synth"], default = "Xtal" }
+Use_SWO_Trace = { type = "Boolean", default = true }
+Use_Reset_Pin = { type = "Boolean", default = true }
+
+[[depends-on]]
+gnat_arm_elf = "^14"
+
+[origin]
+hashes = [
+"sha256:14b90776789f9fb295f58f0d25b2260d09675bb8ab67cbb8581fdd040be25022",
+"sha512:0d79c5724fd2a6375e2d20f237a4f317ce337781c814f328459935fa5c7ff313b59d211df4115220bc6fc4cefff627873dd50621f4bce71f451a1e64235e3a3c",
+]
+url = "https://github.com/damaki/nrf52-runtimes/releases/download/v14.1.0/light-tasking-nrf52832-14.1.0.tar.gz"
+

--- a/index/li/light_tasking_nrf52833/light_tasking_nrf52833-14.1.0.toml
+++ b/index/li/light_tasking_nrf52833/light_tasking_nrf52833-14.1.0.toml
@@ -1,0 +1,56 @@
+name = "light_tasking_nrf52833"
+description = "light-tasking runtime for the nRF52833 SoC"
+version = "14.1.0"
+
+long-description = """
+## Usage
+
+First edit your `alire.toml` file and add the following elements:
+ - Add `light_tasking_nrf52833` in the dependency list:
+   ```toml
+   [[depends-on]]
+   light_tasking_nrf52833 = "*"
+   ```
+
+Then edit your project file to add the following elements:
+ - "with" the run-time project file. With this, gprbuild will compile the run-time before your application
+   ```ada
+   with "runtime_build.gpr";
+   ```
+ - Specify the `Target` and `Runtime` attributes:
+   ```ada
+      for Target use runtime_build'Target;
+      for Runtime ("Ada") use runtime_build'Runtime ("Ada");
+   ```
+"""
+
+authors = ["AdaCore", "Daniel King"]
+maintainers = ["Daniel King <damaki.gh@gmail.com>"]
+maintainers-logins = ["damaki"]
+licenses = "GPL-3.0-or-later WITH GCC-exception-3.1"
+tags = ["embedded", "runtime"]
+website = "https://github.com/damaki/nrf52-runtimes"
+
+project-files = ['runtime_build.gpr', 'ravenscar_build.gpr']
+
+[configuration]
+generate_gpr = false
+generate_c = false
+output_dir = "gnat_user"
+
+[configuration.variables]
+Time_Base = { type = "Enum", values = ["RTC0", "RTC1", "RTC2"], default = "RTC2" }
+LFCLK_Src = { type = "Enum", values = ["Xtal", "RC", "Synth"], default = "Xtal" }
+Use_SWO_Trace = { type = "Boolean", default = true }
+Use_Reset_Pin = { type = "Boolean", default = true }
+
+[[depends-on]]
+gnat_arm_elf = "^14"
+
+[origin]
+hashes = [
+"sha256:1175498dc1a491eccb51b1ff1ddddc4c2f8b3c302fa650fbf52a3875d6040fdb",
+"sha512:c92396604b9b4f307a28cff11f5aa3b62d1c7551c25b13fe245deaf8cc3b30b353807caaf839270bf76bb4e20309dbdc9122a77126e563a53420cb1d5a625311",
+]
+url = "https://github.com/damaki/nrf52-runtimes/releases/download/v14.1.0/light-tasking-nrf52833-14.1.0.tar.gz"
+

--- a/index/li/light_tasking_nrf52840/light_tasking_nrf52840-14.1.0.toml
+++ b/index/li/light_tasking_nrf52840/light_tasking_nrf52840-14.1.0.toml
@@ -1,0 +1,56 @@
+name = "light_tasking_nrf52840"
+description = "light-tasking runtime for the nRF52840 SoC"
+version = "14.1.0"
+
+long-description = """
+## Usage
+
+First edit your `alire.toml` file and add the following elements:
+ - Add `light_tasking_nrf52840` in the dependency list:
+   ```toml
+   [[depends-on]]
+   light_tasking_nrf52840 = "*"
+   ```
+
+Then edit your project file to add the following elements:
+ - "with" the run-time project file. With this, gprbuild will compile the run-time before your application
+   ```ada
+   with "runtime_build.gpr";
+   ```
+ - Specify the `Target` and `Runtime` attributes:
+   ```ada
+      for Target use runtime_build'Target;
+      for Runtime ("Ada") use runtime_build'Runtime ("Ada");
+   ```
+"""
+
+authors = ["AdaCore", "Daniel King"]
+maintainers = ["Daniel King <damaki.gh@gmail.com>"]
+maintainers-logins = ["damaki"]
+licenses = "GPL-3.0-or-later WITH GCC-exception-3.1"
+tags = ["embedded", "runtime"]
+website = "https://github.com/damaki/nrf52-runtimes"
+
+project-files = ['runtime_build.gpr', 'ravenscar_build.gpr']
+
+[configuration]
+generate_gpr = false
+generate_c = false
+output_dir = "gnat_user"
+
+[configuration.variables]
+Time_Base = { type = "Enum", values = ["RTC0", "RTC1", "RTC2"], default = "RTC2" }
+LFCLK_Src = { type = "Enum", values = ["Xtal", "RC", "Synth"], default = "Xtal" }
+Use_SWO_Trace = { type = "Boolean", default = true }
+Use_Reset_Pin = { type = "Boolean", default = true }
+
+[[depends-on]]
+gnat_arm_elf = "^14"
+
+[origin]
+hashes = [
+"sha256:4c8e19d1fd97a2d2e57615ecc98f5537cc74da49ec3d2722da8845d785fa9ea9",
+"sha512:fb7a33a87b4a6a979d5ae3d703d80d763806af6c8fd3042a18214786b07f7588bb8f2c70da7f37477b0c8a4d0caa563cb45b9c6d0009ca1aebec370a84baecd7",
+]
+url = "https://github.com/damaki/nrf52-runtimes/releases/download/v14.1.0/light-tasking-nrf52840-14.1.0.tar.gz"
+


### PR DESCRIPTION
This adds v14.1.0 of the light, light-tasking, and embedded runtimes for some nRF52 SoCs.