### PR TITLE
uuids 1.0.0

### DIFF
--- a/index/uu/uuids/uuids-1.0.0.toml
+++ b/index/uu/uuids/uuids-1.0.0.toml
@@ -1,0 +1,38 @@
+name = "uuids"
+description = "Implementation of RFC 9562 Universally Unique IDentifiers (UUIDs)"
+version = "1.0.0"
+
+authors = ["AJ Ianozi"]
+maintainers = ["AJ Ianozi <aj@ianozi.com>"]
+maintainers-logins = ["aj-ianozi"]
+licenses = "MIT"
+website = "https://github.com/AJ-Ianozi/uuids"
+tags = ["uuid", "guid"]
+long-description = """
+
+This library is an attempt to implement UUIDs to the RFC 9562 standard located here: https://www.ietf.org/rfc/rfc9562.html
+
+As of this writing it can identify any UUID's version or variant and create any kind of UUID in the spec:
+* UUIDv1: Gregorian Timestamp with constant data
+* UUIDv3: MD5-hashed
+* UUIDv4: Randomly-generated
+* UUIDv5: SHA1-hashed
+* UUIDv6: Gregorian Timestamp with constant data with better database locality 
+* UUIDv7: UNIX Timestamp with random data, optimized for database locality
+* UUIDv8: Custom UUIDs
+
+All of my unit tests are passing, but am open to more tests plus additional validation on other platforms, especially big endian.
+
+Refer to the [UUIDs Readme](https://github.com/AJ-Ianozi/uuids) for full description.
+
+You can also read the [full API documentation](https://aj-ianozi.github.io/uuids/toc_index.html) which has been generated with [ROBODoc](https://github.com/gumpu/ROBODoc).
+
+"""
+
+[[depends-on]]
+system_random = "^1.0.0"
+
+[origin]
+commit = "d5d6d70cab4d70e3e89bc9e04ff66ee90ac93924"
+url = "git+https://github.com/AJ-Ianozi/uuids.git"
+


### PR DESCRIPTION
Created via `alr publish` with `alr 2.0.2+9b80158`

I created a UUID library in Ada that follows [RFC 9562](https://www.ietf.org/rfc/rfc9562.html) as closely as possible.  More details can be read here: https://github.com/AJ-Ianozi/uuids