### PR TITLE
a0b_stm32f2_generic_exti 0.1.0

### DIFF
--- a/index/a0/a0b_stm32f2_generic_exti/a0b_stm32f2_generic_exti-0.1.0.toml
+++ b/index/a0/a0b_stm32f2_generic_exti/a0b_stm32f2_generic_exti-0.1.0.toml
@@ -1,0 +1,31 @@
+name = "a0b_stm32f2_generic_exti"
+description = "A0B: STM32F2+ Generic EXTI"
+version = "0.1.0"
+
+website = "https://github.com/godunko/a0b-stm32f2-generic_exti"
+authors = ["Vadim Godunko"]
+maintainers = ["Vadim Godunko <vgodunko@gmail.com>"]
+maintainers-logins = ["godunko"]
+licenses = "Apache-2.0 WITH LLVM-exception"
+tags = ["a0b", "embedded", "stm32", "exti"]
+
+project-files = ["gnat/a0b_stm32f2_generic_exti.gpr"]
+
+[configuration]
+generate_ada = false
+generate_c = false
+generate_gpr = true
+
+[[depends-on]]
+a0b_exti = "*"
+a0b_stm32f2_generic_gpio = "*"
+
+[[actions]]
+type = "test"
+directory = "selftest"
+command = ["alr", "build"]
+
+[origin]
+commit = "462715064e668a486d4ee4b09819f6f33709941b"
+url = "git+https://github.com/godunko/a0b-stm32f2-generic_exti.git"
+


### PR DESCRIPTION
Created via `alr publish` with `alr 2.1.0-rc1`