### PR TITLE
a0b_stm32g4_gpio 0.1.0

### DIFF
--- a/index/a0/a0b_stm32g4_gpio/a0b_stm32g4_gpio-0.1.0.toml
+++ b/index/a0/a0b_stm32g4_gpio/a0b_stm32g4_gpio-0.1.0.toml
@@ -1,0 +1,30 @@
+name = "a0b_stm32g4_gpio"
+description = "A0B: STM32G4 GPIO"
+version = "0.1.0"
+
+authors = ["Vadim Godunko"]
+maintainers = ["Vadim Godunko <vgodunko@gmail.com>"]
+maintainers-logins = ["godunko"]
+licenses = "Apache-2.0 WITH LLVM-exception"
+tags = ["a0b", "embedded", "stm32", "stm32g4", "gpio", "exti"]
+
+project-files = ["gnat/a0b_stm32g4_gpio.gpr"]
+
+[configuration]
+generate_ada = false
+generate_c = false
+generate_gpr = true
+
+[[depends-on]]
+a0b_stm32f2_generic_exti = "*"
+a0b_stm32g4 = "*"
+
+[[actions]]
+type = "test"
+directory = "selftest"
+command = ["alr", "build"]
+
+[origin]
+commit = "2bc15160646b448fd070310dfd2110419ed86a73"
+url = "git+https://github.com/godunko/a0b-stm32g4-gpio.git"
+


### PR DESCRIPTION
Created via `alr publish` with `alr 2.1.0-rc1`