### PR TITLE
fix: improper syntax that will be rejected post-2.1 (#1417)

### DIFF
--- a/index/ti/tiny_text/tiny_text-1.0.0.toml
+++ b/index/ti/tiny_text/tiny_text-1.0.0.toml
@@ -6,7 +6,7 @@ authors = ["Jeremy Grosser"]
 maintainers = ["Jeremy Grosser <jeremy@synack.me>"]
 maintainers-logins = ["JeremyGrosser"]
 licenses = "MIT"
-website = ["https://github.com/JeremyGrosser/tiny_text"]
+website = "https://github.com/JeremyGrosser/tiny_text"
 tags = ["font", "hal", "bitmap", "text"]
 
 [[depends-on]]  # This line was added by `alr with`


### PR DESCRIPTION
We had a missing check in index loading logic that should have rejected an unexpected array.