### PR TITLE
wioe5_ham2 release 1.23340.1 Wed May 14 08:00:11 PM PDT 2025

### DIFF
--- a/index/mu/muntsos_aarch64/muntsos_aarch64-10.4.0.toml
+++ b/index/mu/muntsos_aarch64/muntsos_aarch64-10.4.0.toml
@@ -1,0 +1,88 @@
+name = "muntsos_aarch64"
+description = "MuntsOS Embedded Linux support for AArch64 targets"
+tags = ["muntsos", "embedded", "linux", "arm64", "aarch64"]
+version = "10.4.0"
+website = "https://github.com/pmunts/muntsos"
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+
+long-description = """
+# Introduction
+
+This crate modifies an Alire program project to build a cross-compiled
+program for a **[MuntsOS Embedded
+Linux](https://github.com/pmunts/muntsos)** AArch64 / ARMv8 / arm64
+target computer.
+
+The **MuntsOS Embedded Linux** cross toolchain packages must be
+installed on your Linux development computer before you can use this
+crate. See [Application Note
+#1](https://repo.munts.com/muntsos/doc/AppNote1-Setup-Debian.pdf) for
+Debian distributions or [Application Note
+#2](https://repo.munts.com/muntsos/doc/AppNote2-Setup-RPM.pdf) for RPM
+distributions.
+
+Each **MuntsOS Embedded Linux** cross toolchain contains prebuilt **[Ada
+Web Server](https://github.com/AdaCore/aws)** and **[Linux Simple I/O
+Library](https://github.com/pmunts/libsimpleio)** components. Therefore,
+**DO NOT** attempt to **alr with** any of the **aws**, **libsimpleio**,
+**mcp2221**, **remoteio**, **wioe5_ham1**, **wioe5_ham2**, or
+**wioe5_p2p** crates in a project using this crate.
+
+# Environment Variables
+
+If **ALIRE_DISABLESTYLECHECKS** is set to **yes**, the postfetch script
+will disable style checking in the project **.gpr** file.
+
+If **ALIRE_INSTALLMAKEFILE** is set to **yes**, the postfetch script
+will install an optional but useful **Makefile** to the project
+directory.
+
+You can add the following to **~/.bashrc** or its equivalent to
+permanently define these environment variables:
+
+    export ALIRE_DISABLESTYLECHECKS=yes
+    export ALIRE_INSTALLMAKEFILE=yes
+
+# Example
+
+The following commands illustrate how to create an Alire program project
+that will cross-compile a program to run on a **MuntsOS Embedded Linux**
+target computer. The result is a pristine (*i.e.* all temporary, working
+and deliverable files removed) project, suitable for checking into a
+source code control repository.
+
+    alr -n init --bin myexample
+    cd myexample
+    alr -n with muntsos_aarch64
+    ALIRE_DISABLESTYLECHECKS=yes ALIRE_INSTALLMAKEFILE=yes alr action -r post-fetch
+    make reallyclean
+
+See also [Application Note
+#7](https://repo.munts.com/muntsos/doc/AppNote7-Flash-LED-Ada-Alire.pdf).
+"""
+
+project-files = ["aws.gpr", "libsimpleio.gpr"]
+
+[available."case(os)"]
+"linux" = true
+"..." = false
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+muntsos_dev_aarch64 = "*"
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch"]
+
+[origin]
+hashes = [
+"sha256:c6faa7aa5d4cf1a008bb535801eceab3bab867f596ac9025d73bc01ec0c1932b",
+"sha512:74e1d9639463f0b288697faeb1d9a577492272f4015bb779a1f12165c09bc9f88e8e8a6e242317b5a1dbfa0d7278f19d0ef5376c271326239c0f01f5733873ee",
+]
+url = "https://raw.githubusercontent.com/pmunts/alire-crates/ab66f23f09ad44ed0124f97a2ea15b58ad4e2b78/muntsos_aarch64/muntsos_aarch64-10.4.0.tbz2"
+

--- a/index/wi/wioe5_ham1/wioe5_ham1-1.23340.1.toml
+++ b/index/wi/wioe5_ham1/wioe5_ham1-1.23340.1.toml
@@ -1,0 +1,90 @@
+name = "wioe5_ham1"
+version = "1.23340.1"
+description = "Wio-E5 LoRa Transceiver Module Device Driver"
+website = "https://github.com/pmunts/libsimpleio"
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+licenses = "BSD-1-Clause"
+
+long-description = """
+# Introduction
+
+This crate provides the device driver package **Wio_E5.Ham1** for the
+Seeed Studio [Wio-E5 LoRa Transceiver
+Module](https://wiki.seeedstudio.com/LoRa-E5_STM32WLE5JC_Module)
+operating in test *aka* P2P (so-called Peer to Peer or Point to Point)
+broadcast mode.
+
+See
+[WioE5LoRaP2P.pdf](https://repo.munts.com/libsimpleio/doc/WioE5LoRaP2P.pdf)
+for more information about the [LoRa wireless
+system](https://www.semtech.com/lora/what-is-lora) and operating the
+Wio-E5 module in P2P mode.
+
+**Wio_E5.Ham1** is derived from **Wio_E5.P2P** (see crate
+[wioe5_p2p](https://alire.ada.dev/crates/wioe5_p2p.html)). It reserves
+the first twelve bytes of the payload for address information to
+implement ***[Amateur
+Radio](https://www.fcc.gov/wireless/bureau-divisions/mobility-division/amateur-radio-service)
+Unicast Flavor #1***, which creates a amateur radio [Personal Area
+Network](https://en.wikipedia.org/wiki/Personal_area_network), operated
+under a *Technician* or higher license, in the [33-cm
+band](https://en.wikipedia.org/wiki/33-centimeter_band) (902 to 928 MHz
+in the United States, 915 to 928 MHz in New Zealand, and possible
+allocations in other [ITU Region
+2](https://w6hs.net/itu-region-2-member-countries) countries).
+
+*The code for this crate has been extracted from the [Linux Simple I/O
+Library project](https://github.com/pmunts/libsimpleio).*
+
+# API
+
+The API for this device driver is documented in the
+[Wio-E5.Ham1](https://github.com/pmunts/libsimpleio/blob/master/ada/devices/wioe5/wio_e5-ham1.ads)
+package specification.
+
+**Wio-E5.Ham1** is a generic package that must be instantiated with two
+**Positive** value parameters, for maximum payload size (1 to 241 bytes)
+and FIFO queue depth. The default values for the generic formal
+parameters will prove satisfactory for most purposes. Depending on what
+kind of data you are going to be sending, you might want reduce the
+maximum payload size to match some other protocol, such as 64 bytes for
+the [Remote I/O
+Protocol](https://repo.munts.com/libsimpleio/doc/RemoteIOProtocol.pdf).
+
+# Minimal Test Program
+
+    WITH Wio_E5.Ham1;
+
+    PROCEDURE HelloWorld IS
+
+      PACKAGE LoRa IS NEW Wio_E5.Ham1;
+
+      dev : LoRa.Device;
+
+    BEGIN
+      dev := LoRa.Create("/dev/ttyUSB0", 115200, "ZZ0ZZZ    ", 1, 915.0);
+      dev.Send("Hello, World!", 2);
+      dev.Shutdown;
+    END HelloWorld;
+
+More example programs are available at:
+<https://github.com/pmunts/libsimpleio/tree/master/ada/programs/wioe5/ham1>.
+"""
+
+tags = ["embedded", "linux", "wioe5", "lora", "radio", "wireless", "ham"]
+
+project-files = ["wioe5_ham1.gpr"]
+
+[available."case(os)"]
+'linux|windows' = true
+"..." = false
+
+[origin]
+hashes = [
+"sha256:f8a15bd3d3f84c115a435a43184bcd051a6e4ef16bf9d594505612122fc08ad4",
+"sha512:4347114857752a569855be87b589038d66f43684402306f9859d6d260db255bef362de8001d431568a74ee301eff356327af78a2af803d61649b3bca2460025f",
+]
+url = "https://raw.githubusercontent.com/pmunts/alire-crates/1a403b346e0bbef15b9f4a8b2f7bb12a2fe2b827/wioe5_ham1/wioe5_ham1-1.23340.1.tbz2"
+

--- a/index/wi/wioe5_ham2/wioe5_ham2-1.23340.1.toml
+++ b/index/wi/wioe5_ham2/wioe5_ham2-1.23340.1.toml
@@ -1,0 +1,90 @@
+name = "wioe5_ham2"
+version = "1.23340.1"
+description = "Wio-E5 LoRa Transceiver Module Device Driver"
+website = "https://github.com/pmunts/libsimpleio"
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+licenses = "BSD-1-Clause"
+
+long-description = """
+# Introduction
+
+This crate provides the device driver package **Wio_E5.Ham2** for the
+Seeed Studio [Wio-E5 LoRa Transceiver
+Module](https://wiki.seeedstudio.com/LoRa-E5_STM32WLE5JC_Module)
+operating in test *aka* P2P (so-called Peer to Peer or Point to Point)
+broadcast mode.
+
+See
+[WioE5LoRaP2P.pdf](https://repo.munts.com/libsimpleio/doc/WioE5LoRaP2P.pdf)
+for more information about the [LoRa wireless
+system](https://www.semtech.com/lora/what-is-lora) and operating the
+Wio-E5 module in P2P mode.
+
+**Wio_E5.Ham2** is derived from **Wio_E5.P2P** (see crate
+[wioe5_p2p](https://alire.ada.dev/crates/wioe5_p2p.html)). It reserves
+the first twenty-two bytes of the payload for address information to
+implement ***[Amateur
+Radio](https://www.fcc.gov/wireless/bureau-divisions/mobility-division/amateur-radio-service)
+Unicast Flavor #2***, which creates a amateur radio [Local Area
+Network](https://en.wikipedia.org/wiki/Local_area_network), operated
+under a *Technician* or higher license, in the [33-cm
+band](https://en.wikipedia.org/wiki/33-centimeter_band) (902 to 928 MHz
+in the United States, 915 to 928 MHz in New Zealand, and possible
+allocations in other [ITU Region
+2](https://w6hs.net/itu-region-2-member-countries) countries).
+
+*The code for this crate has been extracted from the [Linux Simple I/O
+Library project](https://github.com/pmunts/libsimpleio).*
+
+# API
+
+The API for this device driver is documented in the
+[Wio-E5.Ham2](https://github.com/pmunts/libsimpleio/blob/master/ada/devices/wioe5/wio_e5-ham2.ads)
+package specification.
+
+**Wio-E5.Ham2** is a generic package that must be instantiated with two
+**Positive** value parameters, for maximum payload size (1 to 241 bytes)
+and FIFO queue depth. The default values for the generic formal
+parameters will prove satisfactory for most purposes. Depending on what
+kind of data you are going to be sending, you might want reduce the
+maximum payload size to match some other protocol, such as 64 bytes for
+the [Remote I/O
+Protocol](https://repo.munts.com/libsimpleio/doc/RemoteIOProtocol.pdf).
+
+# Minimal Test Program
+
+    WITH Wio_E5.Ham2;
+
+    PROCEDURE HelloWorld IS
+
+      PACKAGE LoRa IS NEW Wio_E5.Ham2;
+
+      dev : LoRa.Device;
+
+    BEGIN
+      dev := LoRa.Create("/dev/ttyUSB0", 115200, "XX0XXX    ", 1, 915.0);
+      dev.Send("Hello, World!", "YY0YYY    ", 1);
+      dev.Shutdown;
+    END HelloWorld;
+
+More example programs are available at:
+<https://github.com/pmunts/libsimpleio/tree/master/ada/programs/wioe5/ham2>.
+"""
+
+tags = ["embedded", "linux", "wioe5", "lora", "radio", "wireless", "ham"]
+
+project-files = ["wioe5_ham2.gpr"]
+
+[available."case(os)"]
+'linux|windows' = true
+"..." = false
+
+[origin]
+hashes = [
+"sha256:b013ee3bbc7ee896e4e82c9914286a27038267a7f434d2a5fb359352d523c1b6",
+"sha512:6c9828a18bb2744a62981d0d63c9b37640d75fa81ed3150a2276ff8b0432ec2d5864f2065dfc4927f2556f5e18cb1dc3339cc7a51a44511e8c716616abdef187",
+]
+url = "https://raw.githubusercontent.com/pmunts/alire-crates/e9ba76f0065303a6c855598f0b349766c77c7243/wioe5_ham2/wioe5_ham2-1.23340.1.tbz2"
+

--- a/index/wi/wioe5_p2p/wioe5_p2p-1.23340.1.toml
+++ b/index/wi/wioe5_p2p/wioe5_p2p-1.23340.1.toml
@@ -1,0 +1,81 @@
+name = "wioe5_p2p"
+version = "1.23340.1"
+description = "Wio-E5 LoRa Transceiver Module P2P Mode Device Driver"
+website = "https://github.com/pmunts/libsimpleio"
+authors = ["Philip Munts"]
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+licenses = "BSD-1-Clause"
+
+long-description = """
+# Introduction
+
+This crate provides the device driver package **Wio_E5.P2P** for the
+Seeed Studio [Wio-E5 LoRa Transceiver
+Module](https://wiki.seeedstudio.com/LoRa-E5_STM32WLE5JC_Module)
+operating in test *aka* P2P (so-called Peer to Peer or Point to Point)
+broadcast mode.
+
+See
+[WioE5LoRaP2P.pdf](https://repo.munts.com/libsimpleio/doc/WioE5LoRaP2P.pdf)
+for more information about the [LoRa wireless
+system](https://www.semtech.com/lora/what-is-lora) and operating the
+Wio-E5 module in P2P mode.
+
+See the related crates
+[wioe5_ham1](https://alire.ada.dev/crates/wioe5_ham1.html) and
+[wioe5_ham2](https://alire.ada.dev/crates/wioe5_ham1.htm2).
+
+*The code for this crate has been extracted from the [Linux Simple I/O
+Library project](https://github.com/pmunts/libsimpleio).*
+
+# API
+
+The API for this device driver is documented in the
+[Wio-E5.P2P](https://github.com/pmunts/libsimpleio/blob/master/ada/devices/wioe5/wio_e5-p2p.ads)
+package specification.
+
+**Wio-E5.P2P** is a generic package that must be instantiated with two
+**Positive** value parameters, for maximum payload size (1 to 253 bytes)
+and FIFO queue depth. The default values for the generic formal
+parameters will prove satisfactory for most purposes. Depending on what
+kind of data you are going to be sending, you might want reduce the
+maximum payload size to match some other protocol, such as 64 bytes for
+the [Remote I/O
+Protocol](https://repo.munts.com/libsimpleio/doc/RemoteIOProtocol.pdf).
+
+# Minimal Test Program
+
+    WITH Wio_E5.P2P;
+
+    PROCEDURE HelloWorld IS
+
+      PACKAGE LoRa IS NEW Wio_E5.P2P;
+
+      dev : LoRa.Device;
+
+    BEGIN
+      dev := LoRa.Create("/dev/ttyUSB0", 115200, 915.0);
+      dev.Send("Hello, World!");
+      dev.Shutdown;
+    END HelloWorld;
+
+More example programs are available at:
+<https://github.com/pmunts/libsimpleio/tree/master/ada/programs/wioe5/p2p>.
+"""
+
+tags = ["embedded", "linux", "wioe5", "lora", "radio", "wireless"]
+
+project-files = ["wioe5_p2p.gpr"]
+
+[available."case(os)"]
+'linux|macos|windows' = true
+"..." = false
+
+[origin]
+hashes = [
+"sha256:c781eab39f1e8cc287a505fc8230d1402712f42afe7df4c92df864e2bf0c8f89",
+"sha512:f85003d92893e787fb9d0de945a2a3a8cc709bdd3a072c03f8965c3b76512c478e61e09323545f48bd5a30534ef72eba5311ba9ae00e819093e68afdda5c44ae",
+]
+url = "https://raw.githubusercontent.com/pmunts/alire-crates/c62b574972e65c5a487e20408ca53d685c20a640/wioe5_p2p/wioe5_p2p-1.23340.1.tbz2"
+


### PR DESCRIPTION
Added new crate wioe5_ham2, for Amateur Radio Unicast Flavor #2.

Back ported some improvements from wioe5_ham2 to wioe5_ham1 and wioe5_p2p.