### PR TITLE
mcp9808_i2c 0.9.0

### DIFF
--- a/index/mc/mcp9808_i2c/mcp9808_i2c-0.9.0.toml
+++ b/index/mc/mcp9808_i2c/mcp9808_i2c-0.9.0.toml
@@ -1,0 +1,18 @@
+name = "mcp9808_i2c"
+description = "MCP9808 I2C library"
+version = "0.9.0"
+
+authors = ["Holger Rodriguez"]
+maintainers = ["Holger Rodriguez <github@roseng.ch>"]
+maintainers-logins = ["hgrodriguez"]
+licenses = "BSD-3-Clause"
+website = "https://github.com/hgrodriguez/mcp9808_i2c"
+tags = ["mcp9808", "sensor", "temperature", "i2c"]
+
+[[depends-on]]
+hal = "^1"
+
+[origin]
+commit = "ef0bb8b559fddf4c737e266061d8bd8db5dc4f62"
+url = "git+https://github.com/hgrodriguez/mcp9808_i2c.git"
+


### PR DESCRIPTION
Created via `alr publish` with `alr 2.1.0`