### PR TITLE
fix: stop-gag for macOS Ports failure on macOS 15

### DIFF
--- a/.github/workflows/build-ports.yml
+++ b/.github/workflows/build-ports.yml
@@ -30,7 +30,9 @@ jobs:
       matrix:
         os:
           - macos-13     # amd64
-          - macos-latest # arm64
+          - macos-14     # arm64
+          # macos-latest breaks the action that sets up MacPorts. See
+          # https://github.com/melusina-org/setup-macports/issues/2
 
     steps:
     - name: Check out alire-index

--- a/index/li/libhello/libhello-1.0.1.toml
+++ b/index/li/libhello/libhello-1.0.1.toml
@@ -15,4 +15,4 @@ url = "git+https://github.com/alire-project/libhello.git"
 
 # We use this crate as a trigger to conveniently test minor changes to
 # metaprocesses of the CI of the repository itself.
-# Last touch: 2025-03-18 21:06 CET
+# Last touch: 2025-08-26 20:09 CET


### PR DESCRIPTION
The `macos-latest` runner points now to macOS 15 and that breaks the action we are using to install Ports: 

https://github.com/melusina-org/setup-macports/issues/2

No obvious alternative action exists so this downgrades the check to use macOS 14 for the time being.