### PR TITLE
eeprom_i2c 8.0.1

### DIFF
--- a/index/ee/eeprom_i2c/eeprom_i2c-8.0.1.toml
+++ b/index/ee/eeprom_i2c/eeprom_i2c-8.0.1.toml
@@ -1,0 +1,18 @@
+name = "eeprom_i2c"
+description = "EEPROM I2C drivers library for embedded platforms"
+version = "8.0.1"
+licenses = "BSD-3-Clause"
+
+authors = ["Holger Rodriguez"]
+maintainers = ["Holger Rodriguez <github@roseng.ch>"]
+maintainers-logins = ["hgrodriguez"]
+tags = ["embedded", "nostd", "eeprom", "rp2040", "i2c"]
+website = "https://github.com/hgrodriguez/eeprom_i2c"
+
+[[depends-on]]  # Added by alr
+hal = "^1"  # Added by alr
+
+[origin]
+commit = "555a0529352e6c18c468b5c7bd78f77751596544"
+url = "git+https://github.com/hgrodriguez/eeprom_i2c.git"
+


### PR DESCRIPTION
Created via `alr publish` with `alr 2.1.0`