### PR TITLE
muntsos_aarch64 release 10.5.1 Wed Sep 17 11:14:40 AM PDT 2025

### DIFF
--- a/index/mu/muntsos_aarch64/muntsos_aarch64-10.5.1.toml
+++ b/index/mu/muntsos_aarch64/muntsos_aarch64-10.5.1.toml
@@ -1,0 +1,92 @@
+name = "muntsos_aarch64"
+authors = ["Philip Munts"]
+description = "MuntsOS Embedded Linux support for AArch64 targets"
+licenses = "BSD-1-Clause"
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+tags = ["muntsos", "embedded", "linux", "arm64", "aarch64"]
+version = "10.5.1"
+website = "https://github.com/pmunts/muntsos"
+
+long-description = """
+# Introduction
+
+This crate modifies an Alire program project to build a cross-compiled
+program for a **[MuntsOS Embedded
+Linux](https://github.com/pmunts/muntsos)** AArch64 / ARMv8 / arm64
+target computer.
+
+The **MuntsOS Embedded Linux** cross toolchain packages must be
+installed on your Linux development computer before you can use this
+crate. See [Application Note
+#1](https://repo.munts.com/muntsos/doc/AppNote1-Setup-Debian.pdf) for
+Debian distributions or [Application Note
+#2](https://repo.munts.com/muntsos/doc/AppNote2-Setup-RPM.pdf) for RPM
+distributions.
+
+# Environment Variables
+
+If **ALIRE_DISABLESTYLECHECKS** is set to **yes**, the postfetch script
+will disable style checking in the project **.gpr** file.
+
+If **ALIRE_INSTALLMAKEFILE** is set to **yes**, the postfetch script
+will install an optional but useful **Makefile** to the project
+directory.
+
+You can add the following to **~/.bashrc** or its equivalent to
+permanently define these environment variables:
+
+    export ALIRE_DISABLESTYLECHECKS=yes
+    export ALIRE_INSTALLMAKEFILE=yes
+
+# Example
+
+The following commands illustrate how to create an Alire program project
+that will cross-compile a program to run on a **MuntsOS Embedded Linux**
+target computer. The result is a pristine (*i.e.* all temporary, working
+and deliverable files removed) project, suitable for checking into a
+source code control repository.
+
+    alr -n init --bin myexample
+    cd myexample
+    alr -n with muntsos_aarch64
+    ALIRE_DISABLESTYLECHECKS=yes ALIRE_INSTALLMAKEFILE=yes alr action -r post-fetch
+    make reallyclean
+
+See also [Application Note
+#7](https://repo.munts.com/muntsos/doc/AppNote7-Flash-LED-Ada-Alire.pdf).
+"""
+
+project-files = ["aws.gpr", "libsimpleio.gpr"]
+
+[available."case(os)"]
+"linux" = true
+"..." = false
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+muntsos_dev_aarch64 = "*"
+
+[[forbids]]
+# This crates contains the functionality of the following crates:
+aws         = "*"
+libsimpleio = "*"
+mcp2221     = "*"
+remoteio    = "*"
+wioe5_ham1  = "*"
+wioe5_ham2  = "*"
+wioe5_p2p   = "*"
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch"]
+
+[origin]
+hashes = [
+"sha256:17cf52550bd5219e7ebe3ace65cab7b98086c8b13a840fbce7954ce7be2afa91",
+"sha512:08e0c4f7515e0f6d2f0f3ef74fc24f99af14e7a8f5a261c3c3df6db0b32a0c9810cbec03aefb370ec052ba622243f1b08f4c85c5f73361b5b1bef4251d85afb9",
+]
+url = "https://raw.githubusercontent.com/pmunts/alire-crates/edd5be1ed9e7dbfc80159681e1008471e9509639/muntsos_aarch64/muntsos_aarch64-10.5.1.tbz2"
+


### PR DESCRIPTION
Added licenses = "BSD-1-Clause"

Added aws, libsimpleio, mcp2221, remoteio, wioe5_ham1, wioe5_ham2, and wioe5_p2p to [[forbids]].

Fixed post-fetch script.