### PR TITLE
VSS: fix packages hashes

### DIFF
--- a/index/vs/vss/vss-22.0.0.toml
+++ b/index/vs/vss/vss-22.0.0.toml
@@ -13,8 +13,8 @@ project-files = ["gnat/vss_text.gpr", "gnat/vss_json.gpr"]
 
 [origin]
 archive-name = "vss-22.0.0.tar.gz"
-url = "https://github.com/AdaCore/VSS/archive/refs/tags/v22.0.0.tar.gz"
-hashes = ["sha512:b38582efc2b334a5b550eb9eacadd721b354f51d4cc26fcb4da1c8e7d241a848d5d3ee2651a72b552e2d5357b9fde46ba48e694f17f49cc2bcdad63d2f9d685e"]
+url = "https://github.com/AdaCore/VSS-archived/archive/refs/tags/v22.0.0.tar.gz"
+hashes = ["sha512:d1887c2bb3862c4b005dfca32e63e1a7f5532f713f77b7e5e9db56fb6d61552e1e469115c8b1d1f4711a06d256acdb8837c62a627d14917d2a12de811c2336e4"]
 
 [[depends-on]]
 gnat = ">=2020|(>=11 & <=2000)"

--- a/index/vs/vss/vss-23.0.0.toml
+++ b/index/vs/vss/vss-23.0.0.toml
@@ -16,8 +16,8 @@ disabled = true
 
 [origin]
 archive-name = "vss-23.0.0.tar.gz"
-url = "https://github.com/AdaCore/VSS/archive/refs/tags/v23.0.0.tar.gz"
-hashes = ["sha512:11e762a6ade7137acb32c0776db06244b40a137df90ee5d25855503deeba2a22e6e962ed56d991c71fd27a514edca22ff3d35b0f783855e2d670eb6b45aa4c03"]
+url = "https://github.com/AdaCore/VSS-archived/archive/refs/tags/v23.0.0.tar.gz"
+hashes = ["sha512:8bc153826ac40ea014141ae43ec7939c6cd2da51cafe9841f9b582a877a3b5b4177d7a469684d409dac93f4a470a9c88f38e44eb186af9361b0fef5ceb3ec8de"]
 
 [[depends-on]]
-gnat = ">=12 & <=2000"
+gnat = ">=12 & <13.3.0"

--- a/index/vs/vss/vss-24.0.0.toml
+++ b/index/vs/vss/vss-24.0.0.toml
@@ -12,11 +12,12 @@ website = "https://github.com/AdaCore/VSS"
 project-files = ["gnat/vss_text.gpr", "gnat/vss_json.gpr", "gnat/vss_regexp.gpr", "gnat/vss_xml.gpr", "gnat/vss_xml_templates.gpr"]
 
 [[depends-on]]
-gnat = ">=11 & <2000" # Uses Ada 2022 syntax
+gnat = ">=11 & <15"
 
 [configuration]
 disabled = true
 
 [origin]
-url="https://github.com/adacore/VSS/archive/v24.0.0/VSS-24.0.0.zip"
-hashes=['sha512:b4d0be7c8cdfc30d5221cdb568882b9a5e45d18264ed4e419091efa65da2227c84ba60b725ffb56820672e641922df45dbd790fac1f9b1aa1df75b605de4fc4e']
+archive-name = "vss-24.0.0.tar.gz"
+url="https://github.com/adacore/VSS-archived/archive/refs/tags/v24.0.0.tar.gz"
+hashes=["sha512:5a4c244e27b99b52c82892537ac11b51961c70d18f8b36d0893a7831751d0a6e680a08d66f8a2116dc75862d2694fbab8b178f920073c340913e02e645961142"]

--- a/index/vs/vss/vss-25.0.0.toml
+++ b/index/vs/vss/vss-25.0.0.toml
@@ -18,5 +18,6 @@ gnat = ">=11 & <2000" # Uses Ada 2022 syntax
 disabled = true
 
 [origin]
-url="https://github.com/adacore/VSS/archive/v25.0.0/VSS-25.0.0.zip"
-hashes=['sha512:1ddbb26c99e951f71b03933614a263966e785c098d7abb557ea24a35f516bd9fe5f66367b44e8355e29f4f22f9493dfd6eb9029540cbcfe94f2e4cace96dabc0']
+archive-name = "vss-25.0.0.tar.gz"
+url = "https://github.com/adacore/VSS-archived/archive/refs/tags/v25.0.0.tar.gz"
+hashes = ["sha512:d32b3f5213f3909423633380743824a020bb0d6ef1f0157fa223c3a38110bc161b9739c3bf0b4c82c202d832b86e9e429eabcfd019505cc215785ca2b08e24bc"]


### PR DESCRIPTION
The recent renaming of the VSS git repo to VSS-archived (which was split into VSS-text and VSS-extra for future development) broke the VSS package on Alire.