### PR TITLE
spark_argon2id 1.3.0

### DIFF
--- a/index/sp/spark_argon2id/spark_argon2id-1.3.0.toml
+++ b/index/sp/spark_argon2id/spark_argon2id-1.3.0.toml
@@ -1,0 +1,25 @@
+name = "spark_argon2id"
+version = "1.3.0"
+description = "Pure SPARK Ada implementation of Argon2id (RFC 9106, version 0x13)"
+licenses = "Apache-2.0"
+authors = ["AnubisQuantumCipher <sic.tau@pm.me>"]
+maintainers = ["AnubisQuantumCipher <sic.tau@pm.me>"]
+maintainers-logins = ["AnubisQuantumCipher"]
+website = "https://github.com/AnubisQuantumCipher/spark_argon2id"
+tags = ["cryptography", "argon2", "password", "spark"]
+project-files = ["spark_argon2id.gpr"]
+
+long-description = """
+Argon2id password hashing (RFC 9106, version 0x13). Memory-hard function with SPARK contracts for formal verification.
+"""
+
+[[depends-on]]
+gnatprove = "^14.1"
+
+[origin]
+hashes = [
+"sha256:04d0aad80ce9736053bbc9f52b83c594d8ce788bbc4bb85b41dba5dc0de16a93",
+"sha512:84c8432da3b5a65f5b215e4405bf3d42508ba022d3281b1adb23852ec6984f843efcc7f8d0f574c54b27800be71aca084d7ab9cffdd8565e11efb9cfdb304012",
+]
+url = "https://github.com/AnubisQuantumCipher/spark_argon2id/archive/refs/tags/v1.3.0.tar.gz"
+


### PR DESCRIPTION
New crate submission: spark_argon2id v1.3.0

**Package**: spark_argon2id
**Version**: 1.3.0
**Description**: Pure SPARK Ada implementation of Argon2id (RFC 9106, version 0x13)

## Details

- **License**: Apache-2.0
- **Author**: AnubisQuantumCipher <sic.tau@pm.me>
- **Website**: https://github.com/AnubisQuantumCipher/spark_argon2id
- **Tags**: cryptography, argon2, password, spark

## Features

- RFC 9106 compliant Argon2id (version 0x13)
- Production mode with 1 GiB memory cost (heap allocated)
- Formal verification with SPARK contracts
- Zero FFI dependencies for core algorithm
- 8/8 Known Answer Tests passing

## Testing

- ✅ Smoke tests: PASS
- ✅ RFC 9106 KAT: 8/8 PASS
- ✅ GitHub Actions CI/CD: PASS
- ✅ Source integrity: 52/52 files verified

## Build Requirements

- Ada 2022 (GNAT 14.1+ or GNAT Pro 25.0+)
- GPRbuild 24.0+

## Dependencies

- gnatprove^14.1

## Source Archive

URL: https://github.com/AnubisQuantumCipher/spark_argon2id/archive/refs/tags/v1.3.0.tar.gz

SHA256: 04d0aad80ce9736053bbc9f52b83c594d8ce788bbc4bb85b41dba5dc0de16a93
SHA512: 84c8432da3b5a65f5b215e4405bf3d42508ba022d3281b1adb23852ec6984f843efcc7f8d0f574c54b27800be71aca084d7ab9cffdd8565e11efb9cfdb304012

## Documentation

- README: Complete overview and quick start guide
- BUILDING: Build instructions and troubleshooting
- ARCHITECTURE: Implementation details
- SECURITY: Security properties and guarantees
- PERFORMANCE: Performance analysis
- VERIFY: Source verification guide

Repository: https://github.com/AnubisQuantumCipher/spark_argon2id