### PR TITLE
Ada Binding to the GNU Binutils library

### DIFF
--- a/index/bf/bfdada/bfdada-1.3.1.toml
+++ b/index/bf/bfdada/bfdada-1.3.1.toml
@@ -51,12 +51,12 @@ command = ["sh", "configure"]
 
 [[actions]]
 type = "post-fetch"
-command = ["make"]
+command = ["make", "static"]
 
 [configuration]
 disabled = true
 
 [origin]
-commit = "f0df1fe5d5edc17778492d0e068a8b80e8b2f739"
+commit = "e532f03dbf30904f7a733b460a7300fc0e9d644c"
 url = "git+https://github.com/stcarrez/ada-bfd.git"
 

--- a/index/bf/bfdada/bfdada-1.3.1.toml
+++ b/index/bf/bfdada/bfdada-1.3.1.toml
@@ -1,0 +1,62 @@
+description = "Ada API for the GNU Binutils BFD library"
+name = "bfdada"
+version = "1.3.1"
+authors = ["Stephane.Carrez@gmail.com"]
+licenses = "GPL-2.0-or-later WITH GCC-exception-2.0"
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+project-files = ["bfdada.gpr"]
+tags = ["object", "binary", "elf", "symbols", "disassembler"]
+website = "https://gitlab.com/stcarrez/ada-bfd"
+long-description = """
+
+[![Build Status](https://img.shields.io/endpoint?url=https://porion.vacs.fr/porion/api/v1/projects/ada-bfd/badges/build.json)](https://porion.vacs.fr/porion/projects/view/ada-bfd/summary)
+[![Test Status](https://img.shields.io/endpoint?url=https://porion.vacs.fr/porion/api/v1/projects/ada-bfd/badges/tests.json)](https://porion.vacs.fr/porion/projects/view/ada-bfd/xunits)
+[![Coverage](https://img.shields.io/endpoint?url=https://porion.vacs.fr/porion/api/v1/projects/ada-bfd/badges/coverage.json)](https://porion.vacs.fr/porion/projects/view/ada-bfd/summary)
+
+The Ada-BFD is a library which provides Ada API for GNU Binutils BFD
+library.  It works on any version of GNU Binutils (starting at 2.15).
+The recommended version for GNU Binutils is at least the 2.42.
+
+The Ada-BFD library allows to:
+
+* list and scan the ELF sections of an executable or object file,
+* get the content of the ELF sections,
+* get access to the symbol table,
+* use the BFD disassembler
+
+# Documentation
+
+* [BFD Documentation](http://sourceware.org/binutils/docs/bfd/index.html)
+* [Reading a program symbol table with Ada BFD](https://blog.vacs.fr/vacs/blogs/post.html?post=2012/11/03/Reading-a-program-symbol-table-with-Ada-Bfd)
+
+"""
+
+[gpr-externals]
+BFDADA_BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]
+BFDADA_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+
+[available.'case(os)']
+linux = true
+windows = false
+macos = false
+'...' = false
+
+[[depends-on]]
+gnat = ">=13"
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "configure"]
+
+[[actions]]
+type = "post-fetch"
+command = ["make"]
+
+[configuration]
+disabled = true
+
+[origin]
+commit = "f0df1fe5d5edc17778492d0e068a8b80e8b2f739"
+url = "git+https://github.com/stcarrez/ada-bfd.git"
+


### PR DESCRIPTION
The Ada-BFD library allows to:

* list and scan the ELF sections of an executable or object file,
* get the content of the ELF sections,
* get access to the symbol table,
* use the BFD disassembler

Requires some binutils-dev