### PR TITLE
Add system dependency for libbfd through the binutils-dev Debian package

### DIFF
--- a/index/li/libbfd/libbfd-external.toml
+++ b/index/li/libbfd/libbfd-external.toml
@@ -1,0 +1,16 @@
+description = "GNU Binutils BFD libraries"
+name = "libbfd"
+
+maintainers = ["Stephane.Carrez@gmail.com"]
+maintainers-logins = ["stcarrez"]
+
+[[external]]
+kind = "system"
+[external.origin."case(distribution)"]
+"debian|ubuntu" = ["binutils-dev"]
+
+# No binutils on Windows and MacOS
+[external.available.'case(os)']
+linux = true
+'...' = false
+


### PR DESCRIPTION
This is necessary for the bfdada crate and the Memory Analysis Tool crate that I plan to submit.
