### PR TITLE
AWS 25.0 crate (proposal)

### DIFF
--- a/index/aw/aws/aws-25.0.0.toml
+++ b/index/aw/aws/aws-25.0.0.toml
@@ -1,0 +1,60 @@
+description = "Ada Web Server"
+website = "https://github.com/adacore/aws"
+name = "aws"
+version = "25.0.0"
+authors = ["AdaCore"]
+licenses = "GPL-3.0-only WITH GCC-exception-3.1"
+maintainers = ["chouteau@adacore.com"]
+maintainers-logins = ["Fabien-Chouteau"]
+project-files = ["aws.gpr", "build/projects/aws_config.gpr"]
+tags = ["aws", "web", "server", "http", "https", "soap", "wsdl", "ssl"]
+
+[gpr-externals]
+TGT_DIR = ""
+TARGET = ""
+PRJ_TARGET = ["Windows_NT", "UNIX", "Darwin", "vxworks", "freebsd"]
+
+[gpr-set-externals."case(os)".linux]
+PRJ_TARGET = "UNIX"
+TGT_DIR = "../build"
+TARGET = "build"
+
+[gpr-set-externals."case(os)".freebsd]
+PRJ_TARGET = "freebsd"
+TGT_DIR = "../build"
+TARGET = "build"
+
+[gpr-set-externals."case(os)".windows]
+PRJ_TARGET = "Windows_NT"
+TGT_DIR = "../build"
+TARGET = "build"
+
+[gpr-set-externals."case(os)".macos]
+PRJ_TARGET = "Darwin"
+TGT_DIR = "../build"
+TARGET = "build"
+
+# Since the AWS project doesn't build alone with just gprbuild we build and
+# install with the Makefile from post-fetch actions.
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "mkdir -p `gcc -dumpmachine`/setup/src"]
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "make setup ZLIB=false DEMOS=false LAL=false XMLADA=true SOCKET=openssl prefix=install_dir PRJ_BUILD=Release"]
+
+[[actions]]
+type = "post-fetch"
+command = ["sh", "-c", "mv `gcc -dumpmachine`/ build/"]
+
+[[depends-on]]
+xmlada = "~25.0.0"
+gnatcoll = "~25.0.0"
+make = "*"
+gnat = ">=12"
+openssl = ">=1.1.0"
+
+[origin]
+url="https://github.com/AdaCore/aws/releases/download/v25.0.0/aws-25.0.0-with-templates-parser.zip"
+hashes=['sha512:cf1dc186d2ca7545ae776332e3f03198e920e48dba974275b7c1161786a0af7de823cd2053aeda5ee31072f42db13494b69d51e9879298981fa2a2ae5c94aa38']


### PR DESCRIPTION
This is a proposal for another way to integrate the Ada Web Server as a crate. The issue with the current approach is the Makefile-based environment used by AWS and the fact that we have to completely build and then install AWS to use it.

In this proposal, only the 'make setup' phase is done to let the AWS Makefile do the important setup and prepare the required files in target directory. That target directory is named by AWS by using `gcc -dumpmachine` which brings other issues and to solve and fix things, that directory is moved to a fixed directory `build` so that every target will use that fix value.

The installation and build is not made and instead we reference the two important GNAT projects 'aws.gpr' (top-level) and `build/projects/aws_config.gpr` which was generated by `make setup`.  The build is then handled by Alire since it knowns the AWS projects.  The AWS GNAT projects rely on the following important variables which are set through the makefiles and we can set them for each target as follows:

TGT_DIR = "../build"
TARGET = "build"

It is a proposal in the hope it will solve the AWS crate integration issues....