### PR TITLE
Update Ada Utility Library XML and AWS crate dependencies to build wi…

### DIFF
--- a/index/ut/utilada_aws/utilada_aws-2.8.2.toml
+++ b/index/ut/utilada_aws/utilada_aws-2.8.2.toml
@@ -28,7 +28,7 @@ An alternate HTTP backend is provided by CURL with `utilada_curl`.
 
 [[depends-on]]
 utilada = "^2.8.1"
-aws = "^24.0"
+aws = "^24.0|^25.0"
 
 [gpr-externals]
 UTIL_AWS_IMPL = ["1", "2", "3"]

--- a/index/ut/utilada_xml/utilada_xml-2.8.2.toml
+++ b/index/ut/utilada_xml/utilada_xml-2.8.2.toml
@@ -25,7 +25,7 @@ This library provides a serialization framework on top of XML/Ada for Ada Utilit
 
 [[depends-on]]
 utilada = "^2.8.2"
-xmlada = "^24.0"
+xmlada = "^24.0|^25.0"
 
 [gpr-externals]
 UTIL_BUILD = ["distrib", "debug", "optimize", "profile", "coverage"]


### PR DESCRIPTION
…th AWS 24 or AWS 25

This only update the `xmlada` or `aws` dependencies in the crate declaration so that these two crates can be used with AWS 25 + XML 25 as well as AWS 25 + XML 24 The declarations:

aws = "^24.0"
xmlada = "^24.0"

are not enough to allow that and the pull request only change them to accept ^25.0 explicitly.