### PR TITLE
muntsos_raspberrypi1 release 11.0.0 Fri Nov 21 06:55:57 PM PST 2025

### DIFF
--- a/index/mu/muntsos_raspberrypi1/muntsos_raspberrypi1-11.0.0.toml
+++ b/index/mu/muntsos_raspberrypi1/muntsos_raspberrypi1-11.0.0.toml
@@ -1,0 +1,103 @@
+name = "muntsos_raspberrypi1"
+authors = ["Philip Munts"]
+description = "MuntsOS Embedded Linux support for ARMv6 Raspberry Pi 1 targets"
+licenses = "BSD-1-Clause"
+maintainers = ["Philip Munts <phil@munts.net>"]
+maintainers-logins = ["pmunts"]
+tags = ["muntsos", "embedded", "linux", "arm", "raspberrypi1"]
+version = "11.0.0"
+website = "https://github.com/pmunts/muntsos"
+
+long-description = """
+# Introduction
+
+This crate modifies an Alire program project to build a cross-compiled
+program for a **[MuntsOS Embedded
+Linux](https://github.com/pmunts/muntsos)** ARMv6 Raspberry Pi 1 target
+computer.
+
+The **MuntsOS Embedded Linux** cross toolchain packages must be
+installed on your development computer before you can use this crate.
+See:
+
+[Application Note
+#1](https://repo.munts.com/muntsos/doc/AppNote1-Setup-Debian.pdf) for
+Debian Linux distributions  
+[Application Note
+#2](https://repo.munts.com/muntsos/doc/AppNote2-Setup-RPM.pdf) for RPM
+Linux distributions  
+[Application Note
+#24](https://repo.munts.com/muntsos/doc/AppNote24-Setup-RPM.pdf) for
+x86-64 Windows 10 or 11.
+
+# Environment Variables
+
+If **`ALIRE_DISABLESTYLECHECKS`** is set to **`yes`**, the postfetch
+script will disable style checking in the project **`.gpr`** file.
+
+If **`ALIRE_INSTALLMAKEFILE`** is set to **`yes`**, the postfetch script
+will install an optional but useful **`Makefile`** to the project
+directory.
+
+You can add the following to **`~/.bashrc`** or its equivalent to
+permanently define these environment variables:
+
+    export ALIRE_DISABLESTYLECHECKS=yes
+    export ALIRE_INSTALLMAKEFILE=yes
+
+# Example
+
+The following commands illustrate how to create an Alire program project
+that will cross-compile a program to run on a **MuntsOS Embedded Linux**
+target computer. The result is a pristine (*i.e.* all temporary, working
+and deliverable files removed) project, suitable for checking into a
+source code control repository.
+
+    alr -n init --bin myexample
+    cd myexample
+    alr -n with muntsos_raspberrypi1
+    ALIRE_DISABLESTYLECHECKS=yes ALIRE_INSTALLMAKEFILE=yes alr action -r post-fetch
+    make reallyclean
+
+See also [Application Note
+#7](https://repo.munts.com/muntsos/doc/AppNote7-Flash-LED-Ada-Alire.pdf).
+"""
+
+project-files = ["aws.gpr", "libsimpleio.gpr"]
+
+[available."case(os)"]
+"linux|windows" = true
+"..." = false
+
+[configuration]
+disabled = true
+
+[[depends-on]]
+[depends-on."case(os)"."linux"]
+muntsos_dev_raspberrypi1 = "*"
+
+[[forbids]]
+# This crate contains the functionality of the following crates:
+aws         = "*"
+libsimpleio = "*"
+mcp2221     = "*"
+remoteio    = "*"
+wioe5_ham1  = "*"
+wioe5_ham2  = "*"
+wioe5_p2p   = "*"
+
+[[actions."case(os)".linux]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch.linux"]
+
+[[actions."case(os)".windows]]
+type = "post-fetch"
+command = ["sh", "-c", "./postfetch.windows"]
+
+[origin]
+hashes = [
+"sha256:9c97871c8ed96550918dd3558617e747da254f067a8ccecba7a4c5c436262dbe",
+"sha512:9ef92328139ea1e26931d20a001fc05246c893e90b3678244a10374c38b44acb77338ea8e001d186d4fa97c746f4159cb5b81d06a8635ac84c6475d6cebf2431",
+]
+url = "https://raw.githubusercontent.com/pmunts/alire-crates/e11cfb6abed15d2daf4272b335ec7db2ec96fe03/muntsos_raspberrypi1/muntsos_raspberrypi1-11.0.0.tbz2"
+


### PR DESCRIPTION
Added support for running the MuntsOS cross-toolchain on x86-64 Windows.