### PR TITLE
transition retired macos-13 images to macos-15-intel

### DIFF
--- a/.github/workflows/build-native-master.yml
+++ b/.github/workflows/build-native-master.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-13          # amd64
+          - macos-15-intel    # amd64
           - macos-latest      # arm64
           - ubuntu-latest
           - ubuntu-24.04-arm

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-13          # amd64
+          - macos-15-intel    # amd64
           - macos-latest      # arm64
           - ubuntu-latest
           - ubuntu-24.04-arm

--- a/.github/workflows/build-ports.yml
+++ b/.github/workflows/build-ports.yml
@@ -29,10 +29,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-13     # amd64
-          - macos-14     # arm64
-          # macos-latest breaks the action that sets up MacPorts. See
-          # https://github.com/melusina-org/setup-macports/issues/2
+          - macos-15-intel  # amd64
+          - macos-latest    # arm64
 
     steps:
     - name: Check out alire-index

--- a/index/li/libhello/libhello-1.0.1.toml
+++ b/index/li/libhello/libhello-1.0.1.toml
@@ -15,4 +15,4 @@ url = "git+https://github.com/alire-project/libhello.git"
 
 # We use this crate as a trigger to conveniently test minor changes to
 # metaprocesses of the CI of the repository itself.
-# Last touch: 2025-08-26 20:09 CET
+# Last touch: 2025-12-11 10:56 CET


### PR DESCRIPTION
The `macos-15-intel` image is the last x86_64 based image for macos on GitHub.

Also restore the macports workflow to `macos-latest` (the issue appears to be fixed in the actions' repository)