### PR TITLE
vss_text 26.0.0

### DIFF
--- a/index/vs/vss_text/vss_text-26.0.0.toml
+++ b/index/vs/vss_text/vss_text-26.0.0.toml
@@ -1,0 +1,69 @@
+name = "vss_text"
+description = "A high level Unicode text processing library"
+
+long-description = """
+This crate is based on [`VSS`](https://github.com/AdaCore/VSS) (Virtual
+String System). VSS has been split into two crates:
+
+* [`vss_text`](https://alire.ada.dev/crates/vss_text) (this crate): a library
+  for Unicode text processing.
+* [`vss_extra`](https://alire.ada.dev/crates/vss_extra): libraries for handling
+  JSON, Regexp, XML and other features based on `vss_text`.
+
+Significant changes are planned in `vss_text` with the goal to make it a
+high-quality, high-performance library suitable for a wide range of
+applications.
+
+The changes include the following (non-exhaustive list):
+
+* API Changes
+  * Introduce an immutable string type.
+  * Repurpose the mutable `Virtual_String` type to a string builder type.
+  * Possibly rename the root package `VSS` to a new more appropriate name. Alire crate,
+    GPR project and repository names might change accordingly.
+* (done) Drop the support of multiple internal encodings in favor of a single internal
+  encoding (likely UTF-8) for improved performance.
+"""
+
+version = "26.0.0"
+tags = ["unicode", "string", "text"]
+
+authors = ["AdaCore"]
+maintainers = ["Vadim Godunko <vgodunko@gmail.com>", "Maxim Reznik <reznikmm@gmail.com>", "sagaert@adacore.com", "chouteau@adacore.com"]
+maintainers-logins = ["godunko", "reznikmm", "AldanTanneo", "Fabien-Chouteau"]
+licenses = "Apache-2.0"
+website = "https://github.com/AdaCore/vss-text"
+
+project-files = ["gnat/vss_text.gpr"]
+
+[configuration]
+generate_ada = false
+generate_c = false
+
+[configuration.variables]
+Max_Supported_Integer_Size = {type = "Enum", values = ["128", "64"], default = "128"}
+
+[build-switches]
+"*".ada_version = "Ada2022"
+
+[environment.'case(os)'.linux.LD_LIBRARY_PATH]
+append = "${CRATE_ROOT}/.libs/release/relocatable"
+[environment.'case(os)'.macos.DYLD_LIBRARY_PATH]
+append = "${CRATE_ROOT}/.libs/release/relocatable"
+[environment.'case(os)'.windows.PATH]
+append = "${CRATE_ROOT}/.libs/release/relocatable"
+
+[gpr-externals]
+VSS_OS = ["unix", "osx", "Windows_NT"]
+VSS_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+
+[gpr-set-externals."case(os)".linux]
+VSS_OS = "unix"
+[gpr-set-externals."case(os)".macos]
+VSS_OS = "osx"
+[gpr-set-externals."case(os)".windows]
+VSS_OS = "Windows_NT"
+
+[origin]
+url="https://github.com/AdaCore/vss-text/archive/refs/tags/v26.0.0.zip"
+hashes=['sha512:940443ab7465479f7fa56917a7327dffbc07a5cb643cadf0fc6da549e3dce127dda7b404c2b63d4cf30b51710776903ce4c612aa2cbbb49efe448b28e0bd4e74']


### PR DESCRIPTION
Changed the name of the VSS crate to reflect upstream name change. This will be followed by a `vss_extra` crate.