### PR TITLE
gnatcoll_minimal 26.0.0

### DIFF
--- a/index/gn/gnatcoll_minimal/gnatcoll_minimal-26.0.0.toml
+++ b/index/gn/gnatcoll_minimal/gnatcoll_minimal-26.0.0.toml
@@ -1,0 +1,35 @@
+name = "gnatcoll_minimal"
+version = "26.0.0"
+description = "GNAT Components Collection - Minimal"
+website = "https://github.com/adacore/gnatcoll-core"
+authors = ["AdaCore"]
+licenses = "GPL-3.0-or-later WITH GCC-exception-3.1"
+maintainers = ["chouteau@adacore.com", "sagaert@adacore.com"]
+maintainers-logins = ["Fabien-Chouteau", "AldanTanneo"]
+project-files = ["minimal/gnatcoll_minimal.gpr"]
+tags = ["gnatcoll", "asserts", "encoders", "stream", "storage"]
+
+[configuration]
+disabled = true
+
+[gpr-externals]
+GNATCOLL_BUILD_MODE = ["DEBUG", "PROD"]
+GNATCOLL_OS = ["windows", "unix", "osx"]
+LIBRARY_TYPE = ["static", "relocatable", "static-pic"]
+
+[gpr-set-externals."case(os)".linux]
+GNATCOLL_OS = "unix"
+[gpr-set-externals."case(os)".macos]
+GNATCOLL_OS = "osx"
+[gpr-set-externals."case(os)".windows]
+GNATCOLL_OS = "windows"
+
+[gpr-set-externals]
+GNATCOLL_VERSION = "26.0.0"
+
+[[depends-on]]
+gnat = ">=14"
+
+[origin]
+url="https://github.com/AdaCore/gnatcoll-core/archive/refs/tags/v26.0.0.zip"
+hashes=['sha512:cc5dd0a199115fee269ec1ef963b80abbb56e3029e817d5dbfe71e90fff09d0535ae5be86dedb6d3fbcc74cfa2f3e2e7885de800e5805f9f596507814dce6d4b']


### PR DESCRIPTION
The main GNATCOLL crate got split in 3 crates:

- gnatcoll_minimal, this one, that doesn't depend on anything and has some core functionality
- gnatcoll (actually gnatcoll_core, but Fabien prefers to keep using the previous name), having everything in the old gnatcoll except the libgpr related functionality
- gnatcoll_projects, with the libgpr stuff.

Hopefully we can use gnatcoll in Alire when this is merged, and not the old fork (gnatcoll-slim), since the libgpr dependency is dropped :)