### PR TITLE
sparklib 15.1.0

### DIFF
--- a/index/gn/gnatprove/gnatprove-15.1.0.toml
+++ b/index/gn/gnatprove/gnatprove-15.1.0.toml
@@ -36,7 +36,6 @@ disabled = true
 
 [environment]
 PATH.prepend = "${CRATE_ROOT}/bin"
-GPR_PROJECT_PATH.prepend = "${CRATE_ROOT}/lib/gnat"
 
 [origin."case(os)".windows."case(host-arch)".x86-64]
 url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnatprove-15.1.0-1/gnatprove-x86_64-windows64-15.1.0-1.tar.gz"

--- a/index/sp/sparklib/sparklib-15.1.0.toml
+++ b/index/sp/sparklib/sparklib-15.1.0.toml
@@ -1,0 +1,29 @@
+name = "sparklib"
+version = "15.1.0"
+description = "Companion libraries for SPARK programming"
+website = "https://github.com/AdaCore/SPARKlib"
+authors = ["AdaCore"]
+licenses = "Apache-2.0 WITH LLVM-exception"
+maintainers = ["chouteau@adacore.com", "sagaert@adacore.com"]
+maintainers-logins = ["Fabien-Chouteau", "AldanTanneo"]
+project-files = ["sparklib.gpr"]
+
+configuration.disabled = true
+
+[gpr-externals]
+SPARKLIB_INSTALLED = ["True", "False"]
+
+[gpr-set-externals]
+SPARKLIB_INSTALLED = "False"
+
+[[actions]]
+type = "post-fetch"
+command = ["sed", "-i", "-e", "s/for Object_Dir use \"obj\"/for Object_Dir use \"sparklib_obj\"/", "sparklib.gpr"]
+
+[[forbids]]
+gnatprove = "<15"
+
+[origin]
+url = "git+https://github.com/AdaCore/SPARKlib"
+# fsf-15 branch
+commit = "dc7cd02b08ada6c022d2461092999c1f9b12d879"


### PR DESCRIPTION
This might be a breaking change to remove the include path in `gnatprove-15.1.0.toml`; However, I doubt it, as the current SPARKlib shipped with GNATprove is basically unusable (the gpr is still in template form, it doesn't work out of the box).