### PR TITLE
Add mathpaqs configuration file

### DIFF
--- a/index/ma/mathpaqs/mathpaqs-20260205.0.0.toml
+++ b/index/ma/mathpaqs/mathpaqs-20260205.0.0.toml
@@ -1,0 +1,55 @@
+description = "A collection of mathematical, 100% portable, packages"
+name = "mathpaqs"
+version = "20260205.0.0"
+website = "https://mathpaqs.sourceforge.io/"
+long-description = """
+![Mathpaqs illustration](https://mathpaqs.sourceforge.io/mathpaqs_files/image001.jpg)
+
+Various mathematical packages including algebra, finite elements, random variables, probability dependency models, unlimited integers.
+
+Key features of the Mathpaqs library:
+
+* Standalone
+* Pure Ada
+* Unconditionally portable (*)
+* Tests and demos included
+* **Free**, Open-Source
+
+Some demos, graphical demos and test programs are included.
+___
+
+(*) within limits of compiler's provided integer types and target architecture capacity.
+"""
+authors = ["Gautier de Montmollin"]
+executables = ["arenstorf", "arithmetic_compression",
+   "biomorph", "champ_vt", "cr_demo",
+   "fractal", "ppm2func", "show_floats_limits"]
+   
+#   "test_beta", "test_cholesky", "test_copulas", "test_ert",
+#   "test_estimators", "test_formulas", "test_gamma",
+#   "test_generic_real_linear_equations", "test_normal",
+#   "test_pareto", "test_poisson", "test_qr",
+#   "test_random_performance", "test_rsa",
+#   "test_samples", "test_sparse", "test_u_rand",
+#   "test_discrete_random_simulation"]
+
+project-files = ["mathpaqs_project_tree.gpr"]
+licenses = "MIT"
+maintainers = ["alejandro@mosteo.com"]
+maintainers-logins = ["mosteo", "zertovitch"]
+tags = ["algebra",
+   "contour", "contour-plot",
+   "formula-parser",
+   "fractal",
+   "kutta",
+   "linear-algebra", "mathematics", "matrix",
+   "numerics",
+   "pareto",
+   "poisson",
+   "polynomial", "probability",
+   "random", "rational", "runge", "runge-kutta",
+   "statistics"]
+
+[origin]
+url = "https://sourceforge.net/projects/mathpaqs/files/mathpaqs_2026_02_05.zip"
+hashes = ["sha512:abed7ef9fa92f6941bf0ca1073445d1a717661fdbf5cd54314c08b917158ed93deadcb7ad0352cfa21831b3db07add48254c7fbd948a1856f322cef9de9e1877"]

--- a/index/ma/mathpaqs/mathpaqs-20260205.0.0.toml
+++ b/index/ma/mathpaqs/mathpaqs-20260205.0.0.toml
@@ -50,6 +50,9 @@ tags = ["algebra",
    "random", "rational", "runge", "runge-kutta",
    "statistics"]
 
+[[depends-on]]
+apdf = ">=9.0.0"
+
 [origin]
 url = "https://sourceforge.net/projects/mathpaqs/files/mathpaqs_2026_02_05.zip"
 hashes = ["sha512:abed7ef9fa92f6941bf0ca1073445d1a717661fdbf5cd54314c08b917158ed93deadcb7ad0352cfa21831b3db07add48254c7fbd948a1856f322cef9de9e1877"]


### PR DESCRIPTION
Added a new TOML configuration file for the Mathpaqs library.

This version has a few graphical demos converted from the old "Graph" package to PDF_Out, using the APDF crate.