### PR TITLE
Clean up TeXCAD build mode settings in TOML

### DIFF
--- a/index/te/texcad/texcad-4.5.3.toml
+++ b/index/te/texcad/texcad-4.5.3.toml
@@ -34,9 +34,6 @@ windows = true
 [gpr-externals]
 TeXCAD_Build_Mode = ["Debug", "Optimize"]
 
-[gpr-set-externals]
-TeXCAD_Build_Mode = "Debug"
-
 [[depends-on]]
 gwindows = ">=1.4.3"
 


### PR DESCRIPTION
See comment in PR https://github.com/alire-project/alire-index/pull/1804 for LEA: "Using [gpr-set-externals] here will make the build modes impossible to override by users. Use a default in the GPR file by using External (<VAR>, <default>)."