### PR TITLE
azip 2.7.1 metadata: don't force build profile

### DIFF
--- a/index/az/azip/azip-2.7.1.toml
+++ b/index/az/azip/azip-2.7.1.toml
@@ -43,10 +43,6 @@ windows = true
 [gpr-externals]
 AZip_Build_Mode = ["Debug", "Fast", "Small"]
 
-[gpr-set-externals]
-AZip_Build_Mode = "Small"
-Zip_Build_Mode  = "Small"
-
 [[depends-on]]
 ini_files = ">=11.0.0"
 [[depends-on]]


### PR DESCRIPTION
See comment in PR https://github.com/alire-project/alire-index/pull/1804 for LEA:
"Using [gpr-set-externals] here will make the build modes impossible to override by users. Use a default in the GPR file by using External (VAR, default)."