### PR TITLE
czmq_ada 0.3.0

### DIFF
--- a/index/cz/czmq_ada/czmq_ada-0.3.0.toml
+++ b/index/cz/czmq_ada/czmq_ada-0.3.0.toml
@@ -1,0 +1,18 @@
+name = "czmq_ada"
+version = "0.3.0"
+description = "Ada bindings for CZMQ (high-level C API for ZeroMQ)"
+tags = ["zeromq", "messaging", "networking", "bindings"]
+website = "https://github.com/geewiz/czmq_ada"
+licenses = "MPL-2.0"
+authors = ["Jochen Lillich <contact@geewiz.dev>"]
+maintainers = ["Jochen Lillich <contact@geewiz.dev>"]
+maintainers-logins = ["geewiz"]
+
+notes = """
+Requires CZMQ library to be installed.
+See README.md for installation instructions for your platform.
+"""
+
+[origin]
+commit = "5b7792a7ec5703bbc36a53f6785d426911bdcf83"
+url = "git+https://github.com/geewiz/czmq_ada.git"


### PR DESCRIPTION
## Summary

- Adds `Set_Identity` binding to `CZMQ.Sockets` for DEALER/ROUTER socket identity (closes geewiz/czmq_ada#1)
- Moves test binaries to `tests/bin/` directory
- New test file `test_sockets.adb` for general socket option tests