### PR TITLE
Update external package names for Ubuntu 24 LTS

### DIFF
--- a/index/fl/florist/florist-external.toml
+++ b/index/fl/florist/florist-external.toml
@@ -8,4 +8,4 @@ maintainers-logins = ["mosteo"]
 kind = "system"
    [external.origin."case(distribution)"]
    "debian" = ["libflorist2018-dev"]
-   "ubuntu" = ["libflorist2019-dev"]
+   "ubuntu" = ["libflorist2019-dev", "libflorist-dev"]

--- a/index/nc/ncursesada/ncursesada-external.toml
+++ b/index/nc/ncursesada/ncursesada-external.toml
@@ -10,4 +10,4 @@ kind = "system"
 [external.available."case(toolchain)"]
 user = false
 [external.origin."case(distribution)"]
-"debian|ubuntu" = ["libncursesada6.1.20180127-dev", "libncursesada5-dev", "libncursesada3-dev"]
+"debian|ubuntu" = ["libncursesada6.1.20180127-dev", "libncursesada5-dev", "libncursesada3-dev", "libncursesada-dev"]


### PR DESCRIPTION
This works for a local-only Alire crate. However, I wouldn't be able to publish for distros other than Ubuntu because it needs a `use "ncursesada.gpr";` at the start of `<crate name>.gpr` . I don't know if there's any way to have that "use" statement be conditional based on if an external from the distro was used or not, a cursory search didn't find anything.