### PR TITLE
Add cbor_ada 0.1.0

### DIFF
--- a/index/cb/cbor_ada/cbor_ada-0.1.0.toml
+++ b/index/cb/cbor_ada/cbor_ada-0.1.0.toml
@@ -1,0 +1,24 @@
+name = "cbor_ada"
+description = "CBOR (RFC 8949) encoding/decoding library with SPARK formal verification"
+version = "0.1.0"
+
+authors = ["Baris Erdem"]
+maintainers = ["Baris Erdem <baris@erdem.dev>"]
+maintainers-logins = ["b-erdem"]
+licenses = "Apache-2.0"
+website = "https://github.com/b-erdem/cbor_ada"
+tags = ["cbor", "rfc8949", "serialization", "spark", "embedded", "iot", "verified"]
+
+long-description = """
+SPARK-proved CBOR encoder/decoder for Ada 2022. The encoder and decoder are
+100% formally verified at SPARK Level 2 (486 proof obligations, 0 unproved).
+No heap allocation, pragma Pure, suitable for embedded and safety-critical
+systems. Full RFC 8949 well-formedness validation including shortest-form
+checking, configurable nesting depth, string length limits, and optional
+UTF-8 validation.
+"""
+
+[origin]
+commit = "c6379cb11c656065837aa6f6b20c825c3c18bca7"
+url = "git+https://github.com/b-erdem/cbor_ada.git"
+


### PR DESCRIPTION
## New crate: cbor_ada 0.1.0

SPARK-proved CBOR ([RFC 8949](https://www.rfc-editor.org/rfc/rfc8949)) encoder/decoder for Ada 2022.

### Highlights

- **100% SPARK-proved** at Level 2 — 475 proof obligations, 0 unproved
- Full RFC 8949 well-formedness validation with shortest-form checking
- No heap allocation — stack-only, `pragma Pure`, zero dependencies
- Configurable nesting depth, string length limits, and optional UTF-8 validation
- Apache-2.0 license

### Links

- Repository: https://github.com/b-erdem/cbor_ada
- Manifest generated by `alr publish --skip-submit`