### PR TITLE
Add cbor_ada 0.1.1

### DIFF
--- a/index/cb/cbor_ada/cbor_ada-0.1.1.toml
+++ b/index/cb/cbor_ada/cbor_ada-0.1.1.toml
@@ -1,0 +1,23 @@
+name = "cbor_ada"
+description = "CBOR (RFC 8949) encoding/decoding library with SPARK formal verification"
+version = "0.1.1"
+
+authors = ["Baris Erdem"]
+maintainers = ["Baris Erdem <baris@erdem.dev>"]
+maintainers-logins = ["b-erdem"]
+licenses = "Apache-2.0"
+website = "https://github.com/b-erdem/cbor_ada"
+tags = ["cbor", "rfc8949", "serialization", "spark", "embedded", "iot", "verified"]
+
+long-description = """
+SPARK-proved CBOR encoder/decoder for Ada 2022. The encoder and decoder are
+100% formally verified at SPARK Level 2 (517 proof obligations, 0 unproved).
+No heap allocation, pragma Pure, suitable for embedded and safety-critical
+systems. Full RFC 8949 well-formedness validation including shortest-form
+checking, configurable nesting depth, string length limits, and UTF-8
+validation (enabled by default).
+"""
+
+[origin]
+commit = "4e578607a67722c80c8f2e605e1aef52dbbc1fb5"
+url = "git+https://github.com/b-erdem/cbor_ada.git"


### PR DESCRIPTION
## Summary
- Safety-critical hardening release of `cbor_ada` CBOR (RFC 8949) library
- 517 SPARK proof obligations, 0 unproved (up from 486 in v0.1.0)
- 697 tests, 0 failures

### Changes from 0.1.0
- Fix stale cumulative indefinite-string length tracking
- Add Post contracts to all public encoder/decoder functions
- Enable runtime overflow and validity checks
- Change `Check_UTF8` default to `True` for safer untrusted input handling
- Add `SECURITY.md` threat model documentation
- 21 new edge-case tests