### PR TITLE
Add hmac_ada 0.1.0

### DIFF
--- a/index/hm/hmac_ada/hmac_ada-0.1.0.toml
+++ b/index/hm/hmac_ada/hmac_ada-0.1.0.toml
@@ -1,0 +1,23 @@
+name = "hmac_ada"
+description = "SPARK-proved HMAC (RFC 2104) implementation for Ada/SPARK"
+version = "0.1.0"
+
+authors = ["Baris Erdem"]
+maintainers = ["Baris Erdem <baris@erdem.dev>"]
+maintainers-logins = ["b-erdem"]
+licenses = "Apache-2.0"
+website = "https://github.com/b-erdem/hmac_ada"
+tags = ["hmac", "rfc2104", "cryptography", "spark", "embedded", "security"]
+
+long-description = """
+SPARK-proved HMAC (RFC 2104) with standalone SHA-256 (FIPS 180-4) for Ada 2022.
+174 proof obligations fully discharged at Level 2 with zero pragma Assume.
+Constant-time digest comparison, secure wipe of key material, no heap
+allocation, pragma Pure. Suitable for embedded and safety-critical systems.
+Includes streaming and one-shot APIs, plus a generic HMAC package for other
+hash functions.
+"""
+
+[origin]
+commit = "fa03673fd91b3e8a155ae321d03ca1f0bc839540"
+url = "git+https://github.com/b-erdem/hmac_ada.git"


### PR DESCRIPTION
## Summary

SPARK-proved HMAC (RFC 2104) implementation with standalone SHA-256 (FIPS 180-4) for Ada 2022.

- 174/174 SPARK checks proved at Level 2, 0 assumptions, 0 warnings
- Constant-time digest comparison, secure wipe of key material
- No heap allocation, `pragma Pure`, all stack-bounded
- Streaming and one-shot APIs, plus generic HMAC for other hash functions
- 26 tests: SHA-256, RFC 4231 vectors, streaming, edge cases

Repository: https://github.com/b-erdem/hmac_ada