### PR TITLE
Add ccsds_ada 0.1.0

### DIFF
--- a/index/cc/ccsds_ada/ccsds_ada-0.1.0.toml
+++ b/index/cc/ccsds_ada/ccsds_ada-0.1.0.toml
@@ -1,0 +1,25 @@
+name = "ccsds_ada"
+description = "CCSDS protocol suite with SPARK formal verification"
+version = "0.1.0"
+
+authors = ["Baris Erdem"]
+maintainers = ["Baris Erdem <baris@erdem.dev>"]
+maintainers-logins = ["b-erdem"]
+licenses = "Apache-2.0"
+website = "https://github.com/b-erdem/ccsds_ada"
+tags = ["ccsds", "space", "telemetry", "telecommand", "spark", "embedded", "satellite", "verified", "cfdp", "aos"]
+
+long-description = """
+SPARK-proved CCSDS protocol suite for Ada 2022. Implements Space Packet
+Protocol (133.0-B-1), Time Code Formats (301.0-B-4 CUC/CDS), AOS Transfer
+Frame (732.0-B-4) with FECF, Encapsulation Packet (133.1-B-3), CFDP PDU
+(727.0-B-5) with optional CRC, SLE identifiers (132.0-B-3), and the
+CRC-16-CCITT-FALSE primitive used by AOS and CFDP. 100% formally verified
+at SPARK Level 2 (440 proof obligations, 0 unproved). No heap allocation,
+pragma Pure, suitable for embedded flight software and safety-critical
+ground systems.
+"""
+
+[origin]
+commit = "7632ca9aa6f83c695b5b0fa2d420bf13a2ba8297"
+url = "git+https://github.com/b-erdem/ccsds_ada.git"


### PR DESCRIPTION
SPARK-proved CCSDS protocol suite for Ada 2022.

## Scope

| CCSDS standard | Package | What's covered |
|---|---|---|
| 133.0-B-1 | `CCSDS.Space_Packets` | Primary header encode / decode, full packet encode / decode, field extractors |
| 301.0-B-4 | `CCSDS.Time_Codes` | CUC (unsegmented) and CDS (day-segmented) with P-field |
| 732.0-B-4 | `CCSDS.AOS_Frames` | AOS Transfer Frame primary header + Frame Error Control Field (FECF) |
| 133.1-B-3 | `CCSDS.Encap_Packets` | Encapsulation Packet header |
| 727.0-B-5 | `CCSDS.CFDP` | CFDP PDU header with variable-length entity / transaction IDs, optional two-byte CRC trailer |
| 132.0-B-3 | `CCSDS.SLE` | Service types, delivery modes, bind / instance states, diagnostics (types only) |
| — | `CCSDS.CRC16` | Shared CRC-16-CCITT-FALSE (polynomial 0x1021, seed 0xFFFF) used by AOS FECF and CFDP CRC |

## Quality posture

- **Formally verified**: 440 SPARK Level 2 proof obligations, 0 unproved, 0 justified, 0 `pragma Assume`, 0 warnings. Provers: CVC5 (88%), Z3 (11%), Trivial (1%). Runtime safety (no buffer overflow, no array-index violation, no integer overflow on length / sequence fields, no uninitialised reads) is a direct consequence of the proofs.
- **No heap allocation**; every package is `pragma Pure`. Built on `System.Storage_Elements` — usable on Light and ZFP runtimes, no `Ada.Streams` dependency.
- **No `Unchecked_Conversion`**, `pragma Suppress`, or `System.Address` tricks in the core.
- **Tests**: 260 checks across 4 binaries (`test_space_packets`, `test_time_codes`, `test_stretch`, `test_crc16`), including the Reveng / Rocksoft canonical CRC-16-CCITT-FALSE vectors.
- **CI**: Ubuntu + macOS matrix running build, tests, and `gnatprove --level=2` with an unproved-count gate.
- **Examples**: Four runnable samples under `examples/` (Space Packet round-trip, CUC time code, AOS with FECF and bit-flip detection, CFDP PDU with CRC).

## Dependencies

None beyond the Ada standard library.

## Links

- Source + docs: https://github.com/b-erdem/ccsds_ada
- Commit: `7632ca9`
- Tag: `v0.1.0`
- License: Apache-2.0