### PR TITLE
Add hmac_ada 0.2.0

### DIFF
--- a/index/hm/hmac_ada/hmac_ada-0.2.0.toml
+++ b/index/hm/hmac_ada/hmac_ada-0.2.0.toml
@@ -1,0 +1,29 @@
+name = "hmac_ada"
+description = "SPARK-proved HMAC (RFC 2104) implementation for Ada/SPARK"
+version = "0.2.0"
+
+authors = ["Baris Erdem"]
+maintainers = ["Baris Erdem <baris@erdem.dev>"]
+maintainers-logins = ["b-erdem"]
+licenses = "Apache-2.0"
+website = "https://github.com/b-erdem/hmac_ada"
+tags = ["hmac", "rfc2104", "cryptography", "spark", "embedded", "security"]
+
+long-description = """
+SPARK-proved HMAC (RFC 2104) with standalone SHA-256 (FIPS 180-4) for Ada 2022.
+175 proof obligations fully discharged at Level 2 with zero pragma Assume.
+Constant-time digest comparison (the default `=` operator), secure wipe of
+key material, no heap allocation, pragma Pure. Suitable for embedded and
+safety-critical systems. Includes streaming and one-shot APIs, plus a generic
+HMAC package for other hash functions.
+"""
+
+# Tests and SPARK proofs live in the nested `tests/` crate, which depends on
+# this crate via a local pin. From the repo root:
+#   cd tests && alr build && ./obj/test_hmac
+#   cd tests && alr exec -- gnatprove -P ../hmac_ada.gpr -j0 --level=2 --timeout=120
+
+[origin]
+commit = "6cab790417b3672fe821fdd68f6668026c8e26cb"
+url = "git+https://github.com/b-erdem/hmac_ada.git"
+


### PR DESCRIPTION
## Summary

Second release of [hmac_ada](https://github.com/b-erdem/hmac_ada), incorporating both suggestions from the v0.1.0 review (#1871):

- **`HMAC_Digest` overrides `"="`** with the existing constant-time XOR-accumulation comparison, so the default `Computed = Expected` is safe against timing attacks. `HMAC_SHA256.Equal` is preserved as `renames "="` for code that prefers an explicit name.
- **Tests and `gnatprove` move to a nested `tests/` crate** with a local `path` pin (per the catalog-format spec). The published crate now has zero dev-only dependencies.

Pinned to commit [`6cab790`](https://github.com/b-erdem/hmac_ada/commit/6cab790417b3672fe821fdd68f6668026c8e26cb), tagged [`v0.2.0`](https://github.com/b-erdem/hmac_ada/releases/tag/v0.2.0).

- 175/175 SPARK checks proved at Level 2, 0 unproved, 0 warnings, 0 `pragma Assume`
- 26/26 tests pass on Ubuntu + macOS in CI
- Apache-2.0, no runtime dependencies