### PR TITLE
hkdf_ada 0.1.0

### DIFF
--- a/index/hk/hkdf_ada/hkdf_ada-0.1.0.toml
+++ b/index/hk/hkdf_ada/hkdf_ada-0.1.0.toml
@@ -1,0 +1,32 @@
+name = "hkdf_ada"
+description = "SPARK-proved HKDF (RFC 5869) - HKDF_SHA256 proved at Level 2"
+version = "0.1.0"
+
+authors = ["Baris Erdem"]
+maintainers = ["Baris Erdem <baris@erdem.dev>"]
+maintainers-logins = ["b-erdem"]
+licenses = "Apache-2.0"
+website = "https://github.com/b-erdem/hkdf_ada"
+tags = ["hkdf", "rfc5869", "kdf", "cryptography", "spark", "embedded", "security"]
+
+long-description = """
+SPARK-proved HKDF (RFC 5869) for Ada 2022, built on `hmac_ada`. The
+HKDF-SHA-256 instantiation is fully proved at SPARK Level 2 (266 checks,
+zero `pragma Assume`). Uses `System.Storage_Elements.Storage_Array` for
+embedded and constrained-runtime (Light, ZFP) compatibility, no heap
+allocation, `pragma Pure`. A separate generic `HKDF` package provides an
+unproved convenience layer for other HMAC functions.
+"""
+
+[[depends-on]]
+hmac_ada = "~0.2.0"
+
+# Tests and SPARK proofs live in the nested `tests/` crate, which depends on
+# this crate via a local pin. From the repo root:
+#   cd tests && alr build && ./obj/test_hkdf
+#   cd tests && alr exec -- gnatprove -P ../hkdf_ada.gpr -j0 --level=2 --timeout=120
+
+[origin]
+commit = "cdde31c8e98cc1e101556eeab7c9ed88101a3366"
+url = "git+https://github.com/b-erdem/hkdf_ada.git"
+


### PR DESCRIPTION
First release of `hkdf_ada` — a SPARK-proved HKDF (RFC 5869) implementation in Ada/SPARK.

Built on `hmac_ada ~0.2.0`. The HKDF-SHA-256 instantiation is fully proved at SPARK Level 2 (266/266 checks, zero `pragma Assume`, zero unproved). A separate generic `HKDF` package provides an unproved convenience layer for use with other HMAC functions.

- RFC 5869 Appendix A SHA-256 vectors all pass; boundary-tested at OKM lengths 1, 32, 33, and 8160 (max).
- `pragma Pure`, no heap allocation, stack-bounded — suitable for embedded and constrained-runtime (Light, ZFP) targets.
- Tests and `gnatprove` live in a nested `tests/` crate that depends on the top-level crate via a local `path` pin, so the published crate has zero dev-only dependencies.

Repo: https://github.com/b-erdem/hkdf_ada
Release: https://github.com/b-erdem/hkdf_ada/releases/tag/v0.1.0