### PR TITLE
Removed build of examples in GWindows 1.5.4

### DIFF
--- a/index/gw/gwindows/gwindows-1.5.4.toml
+++ b/index/gw/gwindows/gwindows-1.5.4.toml
@@ -45,16 +45,9 @@ project-files = [
         "gnatcom/gnatcom.gpr",
         "gnatcom/gnatcom_tools.gpr",
         "gwindows/gwindows.gpr",
-        "gwindows/gwindows_contrib.gpr",
-        "gwindows/gwindows_samples.gpr"
+        "gwindows/gwindows_contrib.gpr"
 ]
 executables = [
-        "game_of_life_interactive",
-        "mdi_example",
-        "sci_example",
-        "demo_exlv1",
-        "demo_exlv2",
-        "demo_exlv3",
         "bindcom",
         "comscope",
         "createcom",


### PR DESCRIPTION
Removed build of examples: this causes a new, mysterious issue in at least one crate (LEA) using the GWindows crate. Examples will be built in a separate crate.
Note that gwindows_contrib.gpr also has some own examples but is not exposed to that issue which is related to an extra file added for the linker.