### PR TITLE
ada_imgui 0.1.0

### DIFF
--- a/index/ad/ada_imgui/ada_imgui-0.1.0.toml
+++ b/index/ad/ada_imgui/ada_imgui-0.1.0.toml
@@ -1,0 +1,31 @@
+name = "ada_imgui"
+description = "Ada bindings to Dear ImGui via cimgui"
+version = "0.1.0"
+authors = ["The Dark Factory Ltd"]
+maintainers = ["tony.gair@thedarkfactory.co.uk"]
+maintainers-logins = ["tonygair"]
+licenses = "MIT"
+website = "https://github.com/the-dark-factory/ada-imgui"
+tags = ["binding", "gui", "imgui", "cimgui"]
+project-files = ["ada_imgui.gpr"]
+auto-gpr-with = false
+
+[build-switches]
+"*".style_checks = ["-gnaty"]
+
+#  cimgui (the C++ side) is currently vendored under vendor/cimgui
+#  and built by scripts/build-cimgui.sh. Until that build step is
+#  expressed as an Alire action or the C++ library is packaged as
+#  a separate crate, downstream users must run
+#  `./scripts/build-cimgui.sh` once before `alr build`. Documented
+#  in README.
+
+[available.'case(os)']
+macos = true
+linux = true
+windows = false  # Untested; left off until verified.
+
+[origin]
+commit = "0a03df92f5e7066b7bbb6b10449840b4862f7a29"
+url = "git+https://github.com/the-dark-factory/ada-imgui.git"
+


### PR DESCRIPTION
**Crate**: `ada_imgui` 0.1.0
**Source**: https://github.com/the-dark-factory/ada-imgui
**License**: MIT
**Maintainer**: The Dark Factory Ltd

Bindings to Dear ImGui via cimgui. Immediate-mode GUI for Ada applications.

### Build notes

cimgui (the C++ side) needs to be built once before `alr build`; `scripts/build-cimgui.sh` in the source repo does this. Documented in the crate README. Tested on macOS aarch64 + Alire-shipped GCC 14.

### Context

This is one of three Ada bindings being submitted today by The Dark Factory Ltd (https://github.com/the-dark-factory/ada-imgui → see also `ada-imgui`, `ada-stb`, `ada-ccv` on the same GitHub org). The line is MIT-licensed, dedicated to the Ada community, with the same maintenance posture across the three crates.

Marked draft for initial review — happy to iterate on whatever the index reviewers want (Alire actions for the C-side build, additional metadata, etc.). Flag the concerns and I'll address.