### PR TITLE
ada_stb 0.1.0

### DIFF
--- a/index/ad/ada_stb/ada_stb-0.1.0.toml
+++ b/index/ad/ada_stb/ada_stb-0.1.0.toml
@@ -1,0 +1,30 @@
+name = "ada_stb"
+description = "Ada bindings to Sean Barrett's STB header-only utility libraries"
+version = "0.1.0"
+authors = ["The Dark Factory Ltd"]
+maintainers = ["tony.gair@thedarkfactory.co.uk"]
+maintainers-logins = ["tonygair"]
+licenses = "MIT"
+website = "https://github.com/the-dark-factory/ada-stb"
+tags = ["binding", "image", "stb", "stb-image", "stb-truetype"]
+project-files = ["ada_stb.gpr"]
+auto-gpr-with = false
+
+[build-switches]
+"*".style_checks = ["-gnaty"]
+
+#  STB is header-only C. csrc/stb_impl.c instantiates the
+#  STB_*_IMPLEMENTATION bodies; scripts/build-stb.sh compiles
+#  it into vendor/stb/libstb.a. Until that step is wired as
+#  an Alire action, downstream consumers must run
+#  `./scripts/build-stb.sh` once before `alr build`.
+
+[available.'case(os)']
+macos = true
+linux = true
+windows = false  # Untested.
+
+[origin]
+commit = "6f004c0380b54709b30f4ca4e961e6e7b7be497b"
+url = "git+https://github.com/the-dark-factory/ada-stb.git"
+


### PR DESCRIPTION
**Crate**: `ada_stb` 0.1.0
**Source**: https://github.com/the-dark-factory/ada-stb
**License**: MIT
**Maintainer**: The Dark Factory Ltd

Bindings to Sean Barrett's STB header-only utility libraries. First child is Stb.Image (PNG/JPG/BMP/GIF/PSD/TGA/HDR load).

### Build notes

STB is header-only C; `scripts/build-stb.sh` instantiates the STB_*_IMPLEMENTATION sources into libstb.a once before `alr build`. Documented in the crate README. Tested on macOS aarch64.

### Context

This is one of three Ada bindings being submitted today by The Dark Factory Ltd (https://github.com/the-dark-factory/ada-stb → see also `ada-imgui`, `ada-stb`, `ada-ccv` on the same GitHub org). The line is MIT-licensed, dedicated to the Ada community, with the same maintenance posture across the three crates.

Marked draft for initial review — happy to iterate on whatever the index reviewers want (Alire actions for the C-side build, additional metadata, etc.). Flag the concerns and I'll address.