### PR TITLE
ada_ccv 0.1.0

### DIFF
--- a/index/ad/ada_ccv/ada_ccv-0.1.0.toml
+++ b/index/ad/ada_ccv/ada_ccv-0.1.0.toml
@@ -1,0 +1,41 @@
+name = "ada_ccv"
+description = "Ada bindings to Liu Liu's CCV computer vision library"
+version = "0.1.0"
+authors = ["The Dark Factory Ltd"]
+maintainers = ["tony.gair@thedarkfactory.co.uk"]
+maintainers-logins = ["tonygair"]
+licenses = "MIT"
+website = "https://github.com/the-dark-factory/ada-ccv"
+tags = ["binding", "image", "computer-vision", "ccv"]
+project-files = ["ada_ccv.gpr"]
+auto-gpr-with = false
+
+[build-switches]
+"*".style_checks = ["-gnaty"]
+
+#  CCV is upstream at https://github.com/liuliu/ccv. Downstream
+#  consumers must clone + build it before `alr build`:
+#
+#    git clone https://github.com/liuliu/ccv ~/dev/ccv
+#    cd ~/dev/ccv/lib
+#    PKG_CONFIG_PATH=/opt/homebrew/lib/pkgconfig \
+#      CPPFLAGS="-I/opt/homebrew/include" \
+#      LDFLAGS="-L/opt/homebrew/lib" ./configure
+#    make lib
+#
+#  ada_ccv.gpr's CCV_LIB_DIR environment variable points at
+#  the resulting libccv.a (defaults to ~/dev/ccv/lib).
+#
+#  CCV must be built with HAVE_LIBPNG + HAVE_LIBJPEG detected,
+#  otherwise PNG/JPG reads silently return NULL matrices. See
+#  CHARTER.md for the full build notes.
+
+[available.'case(os)']
+macos = true
+linux = true
+windows = false  # Untested.
+
+[origin]
+commit = "938e54011fa746452c81778ba3a12d999a1b22a5"
+url = "git+https://github.com/the-dark-factory/ada-ccv.git"
+


### PR DESCRIPTION
**Crate**: `ada_ccv` 0.1.0
**Source**: https://github.com/the-dark-factory/ada-ccv
**License**: MIT
**Maintainer**: The Dark Factory Ltd

Bindings to Liu Liu's CCV, a modern C-based computer vision library. v0.1 covers image I/O + color/flip/resample.

### Build notes

CCV is upstream at github.com/liuliu/ccv; users clone + build it once (configure must detect libpng + libjpeg) before `alr build`. Build instructions in the crate's CHARTER.md. Smoke test (read PNG → flip → write PNG) verified end-to-end on macOS aarch64.

### Context

This is one of three Ada bindings being submitted today by The Dark Factory Ltd (https://github.com/the-dark-factory/ada-ccv → see also `ada-imgui`, `ada-stb`, `ada-ccv` on the same GitHub org). The line is MIT-licensed, dedicated to the Ada community, with the same maintenance posture across the three crates.

Marked draft for initial review — happy to iterate on whatever the index reviewers want (Alire actions for the C-side build, additional metadata, etc.). Flag the concerns and I'll address.