### PR TITLE
stb_ada 0.1.0

### DIFF
--- a/index/st/stb_ada/stb_ada-0.1.0.toml
+++ b/index/st/stb_ada/stb_ada-0.1.0.toml
@@ -1,0 +1,30 @@
+name = "stb_ada"
+description = "Ada bindings to Sean Barrett's STB header-only utility libraries"
+version = "0.1.0"
+authors = ["The Dark Factory Ltd"]
+maintainers = ["tony.gair@thedarkfactory.co.uk"]
+maintainers-logins = ["tonygair"]
+licenses = "MIT"
+website = "https://github.com/the-dark-factory/stb-ada"
+tags = ["binding", "image", "stb", "stb-image", "stb-truetype"]
+project-files = ["stb_ada.gpr"]
+auto-gpr-with = false
+
+[build-switches]
+"*".style_checks = ["-gnaty"]
+
+#  STB is header-only C. csrc/stb_impl.c instantiates the
+#  STB_*_IMPLEMENTATION bodies; scripts/build-stb.sh compiles
+#  it into vendor/stb/libstb.a. Until that step is wired as
+#  an Alire action, downstream consumers must run
+#  `./scripts/build-stb.sh` once before `alr build`.
+
+[available.'case(os)']
+macos = true
+linux = true
+windows = false  # Untested.
+
+[origin]
+commit = "008823b9164e888608461613eb94be8b749bb865"
+url = "git+https://github.com/the-dark-factory/stb-ada.git"
+


### PR DESCRIPTION
Created via `alr publish` with `alr 2.1.0`