### PR TITLE
add functional 4.1.1

### DIFF
--- a/index/fu/functional/functional-4.1.1.toml
+++ b/index/fu/functional/functional-4.1.1.toml
@@ -1,0 +1,22 @@
+name = "functional"
+description = "Functional Programming Library for Ada 2022"
+version = "4.1.1"
+
+authors = ["A Bit of Help, Inc. - Michael Gardner"]
+maintainers = ["A Bit of Help, Inc. - Michael Gardner <mjgardner@abitofhelp.com>"]
+maintainers-logins = ["abitofhelp"]
+licenses = "BSD-3-Clause"
+website = "https://github.com/abitofhelp/functional"
+tags = ["functional", "fx", "either", "option", "result", "monad", "error-handling", "ada2022", "spark", "embedded"]
+
+[build-switches]
+"*".Ada_Version = "Ada2022"
+"*".Style_Checks = "yes"
+
+[[depends-on]]
+gnat = ">=13"
+
+[origin]
+commit = "c1ff2600a58b24bf482ec1e44fb63c58c1b1e293"
+url = "git+https://github.com/abitofhelp/functional.git"
+


### PR DESCRIPTION
## Summary

Adds `functional 4.1.1` to the Alire community index.

This is a publishability patch on the `4.1.0` line — restores HTTPS
submodule URLs in `.gitmodules` so consumers can deploy the published
source without SSH credentials. No library API or runtime behavior
delta beyond version metadata; zero `src/` changes between v4.1.0
(tagged but never published to the community index) and v4.1.1.

## Manifest

* Crate: `functional`
* Version: `4.1.1`
* License: `BSD-3-Clause`
* Origin: `git+https://github.com/abitofhelp/functional.git` at commit `c1ff2600a58b24bf482ec1e44fb63c58c1b1e293`
* Direct dependency: `gnat = ">=13"`
* No `[[pins]]`, no path refs, no SSH URLs.

## Validation

* `alr publish --skip-submit` dry-run inside `dev-container-ada-system-1` (Alire 2.1.0) — all 6 steps green; manifest generated bit-identically to this submission.
* `alr publish` real run reached step 8 of 11 (User review, manifest generation, no-conflicting-PR check, fork detection all green); failed at step 9 (local clone workspace setup, container-side filesystem issue unrelated to manifest content). The validated manifest is being submitted manually because the manifest content is identical to what `alr publish` would have submitted.
* `alr build` of `functional=4.1.1/functional.gpr` succeeded in 0.39s during the publish dry-run.

## Tag

* `v4.1.1` annotated tag pushed to https://github.com/abitofhelp/functional
* Tag object: `ef950bf4d5a9da7bd26ccb95988751f6d2731841`
* Tag target commit: `c1ff2600a58b24bf482ec1e44fb63c58c1b1e293`

## Changes since `functional-4.0.0.toml`

* `version` 4.0.0 → 4.1.1
* `[origin] commit` `2203449f...` → `c1ff2600...`
* No other field changes.

Refs: https://github.com/abitofhelp/adafmt/issues/42
