### PR TITLE
df_ccv 0.1.0

### DIFF
--- a/index/df/df_ccv/df_ccv-0.1.0.toml
+++ b/index/df/df_ccv/df_ccv-0.1.0.toml
@@ -1,0 +1,40 @@
+name = "df_ccv"
+description = "Ada bindings to Liu Liu's CCV computer vision library"
+version = "0.1.0"
+authors = ["The Dark Factory Ltd"]
+maintainers = ["tony.gair@thedarkfactory.co.uk"]
+maintainers-logins = ["tonygair"]
+licenses = "MIT"
+website = "https://github.com/the-dark-factory/ccv-ada"
+tags = ["binding", "image", "computer-vision", "ccv"]
+project-files = ["df_ccv.gpr"]
+auto-gpr-with = false
+
+[build-switches]
+"*".style_checks = ["-gnaty"]
+
+#  CCV is upstream at https://github.com/liuliu/ccv. Downstream
+#  consumers must clone + build it before `alr build`:
+#
+#    git clone https://github.com/liuliu/ccv ~/dev/ccv
+#    cd ~/dev/ccv/lib
+#    PKG_CONFIG_PATH=/opt/homebrew/lib/pkgconfig \
+#      CPPFLAGS="-I/opt/homebrew/include" \
+#      LDFLAGS="-L/opt/homebrew/lib" ./configure
+#    make lib
+#
+#  df_ccv.gpr's CCV_LIB_DIR environment variable points at
+#  the resulting libccv.a (defaults to ~/dev/ccv/lib).
+#
+#  CCV must be built with HAVE_LIBPNG + HAVE_LIBJPEG detected,
+#  otherwise PNG/JPG reads silently return NULL matrices. See
+#  CHARTER.md for the full build notes.
+
+[available.'case(os)']
+macos = true
+linux = true
+windows = false  # Untested.
+
+[origin]
+commit = "ec4e224e77c7ec669663a887b80bec416f1dec84"
+url = "git+https://github.com/the-dark-factory/ccv-ada.git"

--- a/index/df/df_ccv/df_ccv-0.1.0.toml
+++ b/index/df/df_ccv/df_ccv-0.1.0.toml
@@ -10,25 +10,10 @@ tags = ["binding", "image", "computer-vision", "ccv"]
 project-files = ["df_ccv.gpr"]
 auto-gpr-with = false
 
+notes = "CCV is built separately: clone liuliu/ccv and make lib (needs libpng+libjpeg), then point df_ccv.gpr's CCV_LIB_DIR at libccv.a. See CHARTER.md."
+
 [build-switches]
 "*".style_checks = ["-gnaty"]
-
-#  CCV is upstream at https://github.com/liuliu/ccv. Downstream
-#  consumers must clone + build it before `alr build`:
-#
-#    git clone https://github.com/liuliu/ccv ~/dev/ccv
-#    cd ~/dev/ccv/lib
-#    PKG_CONFIG_PATH=/opt/homebrew/lib/pkgconfig \
-#      CPPFLAGS="-I/opt/homebrew/include" \
-#      LDFLAGS="-L/opt/homebrew/lib" ./configure
-#    make lib
-#
-#  df_ccv.gpr's CCV_LIB_DIR environment variable points at
-#  the resulting libccv.a (defaults to ~/dev/ccv/lib).
-#
-#  CCV must be built with HAVE_LIBPNG + HAVE_LIBJPEG detected,
-#  otherwise PNG/JPG reads silently return NULL matrices. See
-#  CHARTER.md for the full build notes.
 
 [available.'case(os)']
 macos = true


### PR DESCRIPTION
Supersedes #1947 — renamed `ccv_ada` → `df_ccv` to satisfy the new-crate-name policy (no `ada`/`spark` in new crate names). `df_` is our publisher namespace (The Dark Factory). Otherwise unchanged: Ada bindings to Liu Liu's CCV computer vision library.