### PR TITLE
df_stb 0.1.0

### DIFF
--- a/index/df/df_stb/df_stb-0.1.0.toml
+++ b/index/df/df_stb/df_stb-0.1.0.toml
@@ -9,15 +9,14 @@ website = "https://github.com/the-dark-factory/stb-ada"
 tags = ["binding", "image", "stb", "stb-image", "stb-truetype"]
 project-files = ["df_stb.gpr"]
 auto-gpr-with = false
+notes = "STB is header-only C; the post-fetch action builds vendor/stb/libstb.a from csrc/stb_impl.c (plain cc, no extra tooling)."
 
 [build-switches]
 "*".style_checks = ["-gnaty"]
 
-#  STB is header-only C. csrc/stb_impl.c instantiates the
-#  STB_*_IMPLEMENTATION bodies; scripts/build-stb.sh compiles
-#  it into vendor/stb/libstb.a. Until that step is wired as
-#  an Alire action, downstream consumers must run
-#  `./scripts/build-stb.sh` once before `alr build`.
+[[actions]]
+type = "post-fetch"
+command = ["bash", "scripts/build-stb.sh"]
 
 [available.'case(os)']
 macos = true
@@ -25,5 +24,5 @@ linux = true
 windows = false  # Untested.
 
 [origin]
-commit = "c3b07f7e523c00b50e7f138a1bfb314b8c1536d9"
+commit = "c3442adac650bff870167ba26b718115deb780b9"
 url = "git+https://github.com/the-dark-factory/stb-ada.git"

--- a/index/df/df_stb/df_stb-0.1.0.toml
+++ b/index/df/df_stb/df_stb-0.1.0.toml
@@ -1,0 +1,29 @@
+name = "df_stb"
+description = "Ada bindings to Sean Barrett's STB header-only utility libraries"
+version = "0.1.0"
+authors = ["The Dark Factory Ltd"]
+maintainers = ["tony.gair@thedarkfactory.co.uk"]
+maintainers-logins = ["tonygair"]
+licenses = "MIT"
+website = "https://github.com/the-dark-factory/stb-ada"
+tags = ["binding", "image", "stb", "stb-image", "stb-truetype"]
+project-files = ["df_stb.gpr"]
+auto-gpr-with = false
+
+[build-switches]
+"*".style_checks = ["-gnaty"]
+
+#  STB is header-only C. csrc/stb_impl.c instantiates the
+#  STB_*_IMPLEMENTATION bodies; scripts/build-stb.sh compiles
+#  it into vendor/stb/libstb.a. Until that step is wired as
+#  an Alire action, downstream consumers must run
+#  `./scripts/build-stb.sh` once before `alr build`.
+
+[available.'case(os)']
+macos = true
+linux = true
+windows = false  # Untested.
+
+[origin]
+commit = "c3b07f7e523c00b50e7f138a1bfb314b8c1536d9"
+url = "git+https://github.com/the-dark-factory/stb-ada.git"


### PR DESCRIPTION
Supersedes #1948 — renamed `stb_ada` → `df_stb` to satisfy the new-crate-name policy (no `ada`/`spark` in new crate names). `df_` is our publisher namespace (The Dark Factory). Otherwise unchanged: Ada bindings to Sean Barrett's STB header-only utility libraries.