### PR TITLE
df_imgui 0.1.0

### DIFF
--- a/index/df/df_imgui/df_imgui-0.1.0.toml
+++ b/index/df/df_imgui/df_imgui-0.1.0.toml
@@ -1,0 +1,30 @@
+name = "df_imgui"
+description = "Ada bindings to Dear ImGui via cimgui"
+version = "0.1.0"
+authors = ["The Dark Factory Ltd"]
+maintainers = ["tony.gair@thedarkfactory.co.uk"]
+maintainers-logins = ["tonygair"]
+licenses = "MIT"
+website = "https://github.com/the-dark-factory/imgui-ada"
+tags = ["binding", "gui", "imgui", "cimgui"]
+project-files = ["df_imgui.gpr"]
+auto-gpr-with = false
+
+[build-switches]
+"*".style_checks = ["-gnaty"]
+
+#  cimgui (the C++ side) is currently vendored under vendor/cimgui
+#  and built by scripts/build-cimgui.sh. Until that build step is
+#  expressed as an Alire action or the C++ library is packaged as
+#  a separate crate, downstream users must run
+#  `./scripts/build-cimgui.sh` once before `alr build`. Documented
+#  in README.
+
+[available.'case(os)']
+macos = true
+linux = true
+windows = false  # Untested; left off until verified.
+
+[origin]
+commit = "3dec19e9896a15f1194c8c98dc7848324c0faaac"
+url = "git+https://github.com/the-dark-factory/imgui-ada.git"

--- a/index/df/df_imgui/df_imgui-0.1.0.toml
+++ b/index/df/df_imgui/df_imgui-0.1.0.toml
@@ -10,15 +10,14 @@ tags = ["binding", "gui", "imgui", "cimgui"]
 project-files = ["df_imgui.gpr"]
 auto-gpr-with = false
 
+notes = "cimgui (the C++ side) is vendored; the post-fetch action builds vendor/cimgui/libcimgui.a (plain c++, no cmake)."
+
+[[actions]]
+type = "post-fetch"
+command = ["bash", "scripts/build-cimgui.sh"]
+
 [build-switches]
 "*".style_checks = ["-gnaty"]
-
-#  cimgui (the C++ side) is currently vendored under vendor/cimgui
-#  and built by scripts/build-cimgui.sh. Until that build step is
-#  expressed as an Alire action or the C++ library is packaged as
-#  a separate crate, downstream users must run
-#  `./scripts/build-cimgui.sh` once before `alr build`. Documented
-#  in README.
 
 [available.'case(os)']
 macos = true


### PR DESCRIPTION
Supersedes #1949 — renamed `imgui_ada` → `df_imgui` to satisfy the new-crate-name policy (no `ada`/`spark` in new crate names). `df_` is our publisher namespace (The Dark Factory). Otherwise unchanged: Ada bindings to Dear ImGui via cimgui.