### PR TITLE
df_llama 0.1.0

### DIFF
--- a/index/df/df_llama/df_llama-0.1.0.toml
+++ b/index/df/df_llama/df_llama-0.1.0.toml
@@ -9,8 +9,7 @@ website = "https://github.com/the-dark-factory/llama-ada"
 tags = ["binding", "llm", "ai", "llama", "ggml"]
 project-files = ["df_llama.gpr"]
 auto-gpr-with = false
-
-notes = "The binding needs the llama.cpp libraries: build llama.cpp and point LLAMA_CPP_LIB at the build output before alr build. The example also needs a local GGUF model."
+notes = "Needs the llama.cpp shared libraries: build llama.cpp and point LLAMA_CPP_LIB at its build output (gpr default: vendor/llama.cpp/build/bin). The example also needs a local GGUF model."
 
 [build-switches]
 "*".style_checks = "no"
@@ -21,5 +20,5 @@ linux = true
 windows = false  # Untested.
 
 [origin]
-commit = "fb3ae11283fd3ef3b26fbae1bc78ac07413ecc64"
+commit = "0c7c3e9c5c5f47a0c5a32674dd8dda67d284b8cd"
 url = "git+https://github.com/the-dark-factory/llama-ada.git"

--- a/index/df/df_llama/df_llama-0.1.0.toml
+++ b/index/df/df_llama/df_llama-0.1.0.toml
@@ -1,0 +1,30 @@
+name = "df_llama"
+description = "Ada bindings to llama.cpp - run a local LLM on-device from Ada"
+version = "0.1.0"
+authors = ["The Dark Factory Ltd"]
+maintainers = ["tony.gair@thedarkfactory.co.uk"]
+maintainers-logins = ["tonygair"]
+licenses = "MIT"
+website = "https://github.com/the-dark-factory/llama-ada"
+tags = ["binding", "llm", "ai", "llama", "ggml"]
+project-files = ["df_llama.gpr"]
+auto-gpr-with = false
+
+#  The src/ binding is machine-generated (gcc -fdump-ada-spec); skip style checks.
+[build-switches]
+"*".style_checks = "no"
+
+#  The generated src/ binds llama.cpp's C API. The llama.cpp libraries are built
+#  separately (scripts/setup-llama.sh, pinned SHA) into vendor/llama.cpp/build/bin.
+#  Point LLAMA_CPP_LIB at that dir (or another build) before building:
+#    alr build -XLLAMA_CPP_LIB=/path/to/llama.cpp/build/bin
+#  Running the example also needs a GGUF model under models/ (gitignored, large).
+
+[available.'case(os)']
+macos = true
+linux = true
+windows = false  # Untested.
+
+[origin]
+commit = "fb3ae11283fd3ef3b26fbae1bc78ac07413ecc64"
+url = "git+https://github.com/the-dark-factory/llama-ada.git"

--- a/index/df/df_llama/df_llama-0.1.0.toml
+++ b/index/df/df_llama/df_llama-0.1.0.toml
@@ -10,15 +10,10 @@ tags = ["binding", "llm", "ai", "llama", "ggml"]
 project-files = ["df_llama.gpr"]
 auto-gpr-with = false
 
-#  The src/ binding is machine-generated (gcc -fdump-ada-spec); skip style checks.
+notes = "The binding needs the llama.cpp libraries: build llama.cpp and point LLAMA_CPP_LIB at the build output before alr build. The example also needs a local GGUF model."
+
 [build-switches]
 "*".style_checks = "no"
-
-#  The generated src/ binds llama.cpp's C API. The llama.cpp libraries are built
-#  separately (scripts/setup-llama.sh, pinned SHA) into vendor/llama.cpp/build/bin.
-#  Point LLAMA_CPP_LIB at that dir (or another build) before building:
-#    alr build -XLLAMA_CPP_LIB=/path/to/llama.cpp/build/bin
-#  Running the example also needs a GGUF model under models/ (gitignored, large).
 
 [available.'case(os)']
 macos = true

--- a/index/df/df_llama/df_llama-0.1.0.toml
+++ b/index/df/df_llama/df_llama-0.1.0.toml
@@ -20,5 +20,5 @@ linux = true
 windows = false  # Untested.
 
 [origin]
-commit = "0c7c3e9c5c5f47a0c5a32674dd8dda67d284b8cd"
+commit = "f44da7bd5e883a686812a5f8d58e15f40fcc1889"
 url = "git+https://github.com/the-dark-factory/llama-ada.git"


### PR DESCRIPTION
Ada bindings to llama.cpp for in-process, on-device LLM inference (generated thin C-ABI binding plus a Llama.Generate wrapper). The df_ prefix is our publisher namespace (The Dark Factory). No other Ada binding to llama.cpp currently exists.