### PR TITLE
update external gentoo dependencies for lace_gel_full_demo

### DIFF
--- a/index/li/libbullet/libbullet-external.toml
+++ b/index/li/libbullet/libbullet-external.toml
@@ -15,3 +15,4 @@ kind = "system"
 'debian|ubuntu' = ["libbullet-dev"]
 arch            = ["bullet"]
 msys2           = ["mingw-w64-x86_64-bullet"]
+gentoo          = ["sci-physics/bullet"]

--- a/index/li/libexpat/libexpat-external.toml
+++ b/index/li/libexpat/libexpat-external.toml
@@ -11,3 +11,4 @@ kind = "system"
 "debian|ubuntu" = ["libexpat1-dev"]
 arch            = ["expat"]
 msys2           = ["mingw-w64-x86_64-expat"]
+gentoo          = ["dev-libs/expat"]

--- a/index/li/libfreetype/libfreetype-external.toml
+++ b/index/li/libfreetype/libfreetype-external.toml
@@ -12,4 +12,4 @@ arch = ["freetype2"]
 msys2 = ["mingw-w64-x86_64-freetype"]
 homebrew = ["freetype"]
 macports = ["freetype"]
-
+gentoo = ["media-libs/freetype"]

--- a/index/li/libraylib/libraylib-external.toml
+++ b/index/li/libraylib/libraylib-external.toml
@@ -10,3 +10,4 @@ kind = "system"
 "arch|homebrew|macports" = ["raylib"]
 "fedora" = ["raylib-devel"]
 "msys2" = ["mingw-w64-x86_64-raylib"]
+"gentoo" = ["media-libs/raylib"]


### PR DESCRIPTION
It's expected that the lace demo _from alire_ won't work. I already informed the maintainer (See https://github.com/charlie5/lace/issues/1) 