### PR TITLE
clara 1.0.1

### DIFF
--- a/index/cl/clara/clara-1.0.1.toml
+++ b/index/cl/clara/clara-1.0.1.toml
@@ -1,0 +1,23 @@
+name = "clara"
+description = "Type-safe CLI argument parsing with functional monads"
+version = "1.0.1"
+
+authors = ["A Bit of Help, Inc. - Michael Gardner"]
+maintainers = ["A Bit of Help, Inc. - Michael Gardner <mjgardner@abitofhelp.com>"]
+maintainers-logins = ["abitofhelp"]
+licenses = "BSD-3-Clause"
+website = "https://github.com/abitofhelp/clara"
+tags = ["cli", "command-line", "arguments", "parser", "ada2022", "spark", "functional", "type-safe"]
+
+[build-switches]
+"*".Ada_Version = "Ada2022"
+"*".Style_Checks = "yes"
+
+[[depends-on]]
+gnat = ">=13"
+functional = "^4.0.0"
+
+[origin]
+commit = "1dafa0e89978ca214aab806d137b2641668b2458"
+url = "git+https://github.com/abitofhelp/clara.git"
+


### PR DESCRIPTION
## Summary

Initial Alire community-index submission for `clara`, a type-safe CLI argument parsing library for Ada 2022 built on top of [`functional`](https://github.com/abitofhelp/functional) (Result / Option monads, railway-oriented parsing).

This is the first version of clara to be submitted to the community index.

## Why `clara 1.0.1` and not `clara 1.0.0`?

`clara v1.0.0` was tagged in the source repository at [`8b6ea3b`](https://github.com/abitofhelp/clara/commit/8b6ea3bb8682d24429569ac386ce280dfa877280) but **not submitted** here after `alr publish --skip-submit` dry-run validation surfaced SSH submodule URLs in the source repo's `.gitmodules`:

```
fatal: clone of 'git@github.com:abitofhelp/hybrid_scripts_python.git' ... failed
fatal: clone of 'git@github.com:abitofhelp/hybrid_test_python.git' ... failed
```

(The `.gitmodules` only references two **public** Alire-unrelated developer-tooling submodules — `hybrid_scripts_python` and `hybrid_test_python`. The publishability defect was simply that the URLs were the SSH form, which fails the recursive-clone step in credentials-free environments like Alire CI.)

The same publishability defect affected `functional` v4.1.0 → v4.1.1; that was resolved with [abitofhelp/functional#6](https://github.com/abitofhelp/functional/pull/6) and shipped here as `functional 4.1.1` ([alire-index#1951](https://github.com/alire-project/alire-index/pull/1951)). Per project rules (no force-rewrite of public tags), the `clara v1.0.0` tag was preserved at the pre-fix tree, and `v1.0.1` is the first version with the HTTPS `.gitmodules` repair.

## G9-dry validation

`alr publish --skip-submit` against the `v1.0.1` annotated tag in the canonical Alire dev container (`dev-container-ada-system-1`, Alire 2.1.0) — all 5 publishing-assistant steps green:

```
Publishing assistant: step 1 of 5: Verify origin URL
Success: Origin is of supported kind: GIT
Success: Origin is hosted on trusted site: github.com
Publishing assistant: step 2 of 5: Deploy sources
Publishing assistant: step 3 of 5: Build release
Note: Synchronizing workspace...
Note: Building clara=1.0.1/clara.gpr...
Success: Build finished successfully in 1.00 seconds.
Success: Build succeeded.
Publishing assistant: step 4 of 5: User review
Publishing assistant: step 5 of 5: Generate index manifest
Success: Your index manifest file has been generated at /workspace/clara/alire/releases/clara-1.0.1.toml
```

Step 2 ("Deploy sources") — the step that previously failed on `v1.0.0` due to SSH submodules — completed cleanly with no host-key prompts or auth errors.

## Manifest provenance

- Generated by `alr publish --skip-submit` against the `v1.0.1` annotated tag:
  - Tag object SHA: `23e6a76162b27d6198c6db60f6d774ae2f4fb731`
  - Tag target commit: `1dafa0e89978ca214aab806d137b2641668b2458`
- Origin URL: `git+https://github.com/abitofhelp/clara.git` (HTTPS, public)
- Origin commit: `1dafa0e89978ca214aab806d137b2641668b2458` (the `v1.0.1` tag target)
- Manifest **MD5: `7f695a185909a912e56a496ab159af69`**
- The file submitted in this PR is **byte-identical** to the generated manifest.

## Dependencies

- `gnat >= 13`
- `functional ^4.0.0` (already on this community index — `functional 4.1.1` from [alire-index#1951](https://github.com/alire-project/alire-index/pull/1951))

No `[[pins]]`, no `path =` dependencies, no SSH URLs, no private repository references.

## License

`BSD-3-Clause`

## Diff scope

This PR adds exactly one new file:

```
index/cl/clara/clara-1.0.1.toml   (+23 lines)
```

No other files added, modified, or removed.
