### PR TITLE
gnat+cross 15.3.1

### DIFF
--- a/index/gn/gnat_aarch64_elf/gnat_aarch64_elf-15.3.1.toml
+++ b/index/gn/gnat_aarch64_elf/gnat_aarch64_elf-15.3.1.toml
@@ -1,0 +1,41 @@
+name = "gnat_aarch64_elf"
+version = "15.3.1"
+provides = ["gnat=15.3.1"]
+description = "The GNAT Ada compiler - aarch64 cross-compiler"
+maintainers = ["chouteau@adacore.com", "sagaert@adacore.com"]
+maintainers-logins = ["Fabien-Chouteau", "AldanTanneo"]
+licenses = "GPL-3.0-or-later AND GPL-3.0-or-later WITH GCC-exception-3.1"
+website = "https://github.com/alire-project/GNAT-FSF-builds"
+
+auto-gpr-with = false
+
+[configuration]
+disabled = true
+
+[environment]
+PATH.prepend = "${CRATE_ROOT}/bin"
+
+[origin."case(os)".linux."case(host-arch)".x86-64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-aarch64-elf-linux64-x86_64-15.3.0-1.tar.gz"
+hashes = ["sha256:08263f4e59f338fb4208ec015ef1f063f743ed380588a44a128ce8321492af25"]
+
+[origin."case(os)".linux."case(host-arch)".aarch64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-aarch64-elf-linux64-aarch64-15.3.0-1.tar.gz"
+hashes = ["sha256:8df04107103b1473c36dc93494467373a8aeaaca938a46a39df6d7ead43ae18d"]
+
+[origin."case(os)".macos."case(host-arch)".x86-64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-aarch64-elf-darwin-x86_64-15.3.0-1.tar.gz"
+hashes = ["sha256:d5878397fd7c4c0e3061e67d1ab9b30bf83247edb78b4f458b8bbc99ce9437f0"]
+
+[origin."case(os)".macos."case(host-arch)".aarch64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-aarch64-elf-darwin-aarch64-15.3.0-1.tar.gz"
+hashes = ["sha256:113b747396eb88ae46bdc29bf990a037edd4960f931ebc2513295e4573ae8ca0"]
+
+[origin."case(os)".windows."case(host-arch)".x86-64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-aarch64-elf-windows64-x86_64-15.3.0-1.tar.gz"
+hashes = ["sha256:6ad9fff4fa2fa1e9d490a3b0eefa5745361a6078b02b5b4fe6a0e3cc9acd7592"]

--- a/index/gn/gnat_arm_elf/gnat_arm_elf-15.3.1.toml
+++ b/index/gn/gnat_arm_elf/gnat_arm_elf-15.3.1.toml
@@ -1,0 +1,41 @@
+name = "gnat_arm_elf"
+version = "15.3.1"
+provides = ["gnat=15.3.1"]
+description = "The GNAT Ada compiler - ARM cross-compiler"
+maintainers = ["chouteau@adacore.com", "sagaert@adacore.com"]
+maintainers-logins = ["Fabien-Chouteau", "AldanTanneo"]
+licenses = "GPL-3.0-or-later AND GPL-3.0-or-later WITH GCC-exception-3.1"
+website = "https://github.com/alire-project/GNAT-FSF-builds"
+
+auto-gpr-with = false
+
+[configuration]
+disabled = true
+
+[environment]
+PATH.prepend = "${CRATE_ROOT}/bin"
+
+[origin."case(os)".linux."case(host-arch)".x86-64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-arm-elf-linux64-x86_64-15.3.0-1.tar.gz"
+hashes = ["sha256:163eb73f9eaa8ae3ac264c35b1a5edece640ede0060288e7d3ce78aeb4ffa826"]
+
+[origin."case(os)".linux."case(host-arch)".aarch64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-arm-elf-linux64-aarch64-15.3.0-1.tar.gz"
+hashes = ["sha256:5f9466b07c08f59a7a58c5880fd52ffb16a9bdd73555c8d5c80ee85c21f87ab4"]
+
+[origin."case(os)".macos."case(host-arch)".x86-64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-arm-elf-darwin-x86_64-15.3.0-1.tar.gz"
+hashes = ["sha256:1767cd41723a75dbfadb0e82219e50e70877dcd265003a5c2b42e12ab68ac711"]
+
+[origin."case(os)".macos."case(host-arch)".aarch64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-arm-elf-darwin-aarch64-15.3.0-1.tar.gz"
+hashes = ["sha256:e1f477c306a0e7ffb68d8643e6f1b1f3fe88cdcc3f8a33d6a69525d3d8c45b7c"]
+
+[origin."case(os)".windows."case(host-arch)".x86-64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-arm-elf-windows64-x86_64-15.3.0-1.tar.gz"
+hashes = ["sha256:5b86c77f4f502dabcf8a4a24bdcf8cd12c3f5e249c74691f5cde3110028cb908"]

--- a/index/gn/gnat_avr_elf/gnat_avr_elf-15.3.1.toml
+++ b/index/gn/gnat_avr_elf/gnat_avr_elf-15.3.1.toml
@@ -1,0 +1,41 @@
+name = "gnat_avr_elf"
+version = "15.3.1"
+provides = ["gnat=15.3.1"]
+description = "The GNAT Ada compiler - AVR cross-compiler"
+maintainers = ["chouteau@adacore.com", "sagaert@adacore.com"]
+maintainers-logins = ["Fabien-Chouteau", "AldanTanneo"]
+licenses = "GPL-3.0-or-later AND GPL-3.0-or-later WITH GCC-exception-3.1"
+website = "https://github.com/alire-project/GNAT-FSF-builds"
+
+auto-gpr-with = false
+
+[configuration]
+disabled = true
+
+[environment]
+PATH.prepend = "${CRATE_ROOT}/bin"
+
+[origin."case(os)".linux."case(host-arch)".x86-64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-avr-elf-linux64-x86_64-15.3.0-1.tar.gz"
+hashes = ["sha256:3d1bc9d2961f01b194f42e275e7a396fdc3f2ce408bf3f9a7b122c0f5b669310"]
+
+[origin."case(os)".linux."case(host-arch)".aarch64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-avr-elf-linux64-aarch64-15.3.0-1.tar.gz"
+hashes = ["sha256:a48aa50c1a1ae36246769f93901a8c6f4363122eeaca754353ae576762a97473"]
+
+[origin."case(os)".macos."case(host-arch)".x86-64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-avr-elf-darwin-x86_64-15.3.0-1.tar.gz"
+hashes = ["sha256:e3ed171478a244323dfd980e23a87f8a18a7e5bfe4f367b67cfb6e8dcd94a67a"]
+
+[origin."case(os)".macos."case(host-arch)".aarch64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-avr-elf-darwin-aarch64-15.3.0-1.tar.gz"
+hashes = ["sha256:8379f27b1b3c726c1e6df129ab09c4f1149f358c467d35666c96e9296bf85ef0"]
+
+[origin."case(os)".windows."case(host-arch)".x86-64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-avr-elf-windows64-x86_64-15.3.0-1.tar.gz"
+hashes = ["sha256:29ecc31af89d9f164c50027357ca3f4c5f72d7dd82fb45faf105b36713e99e77"]

--- a/index/gn/gnat_native/gnat_native-15.3.1.toml
+++ b/index/gn/gnat_native/gnat_native-15.3.1.toml
@@ -1,0 +1,56 @@
+name = "gnat_native"
+version = "15.3.1"
+provides = ["gnat=15.3.1"]
+description = "The GNAT Ada compiler - Native"
+maintainers = ["Fabien Chouteau <chouteau@adacore.com>", "César Sagaert <sagaert@adacore.com>"]
+maintainers-logins = ["Fabien-Chouteau", "AldanTanneo"]
+licenses = "GPL-3.0-or-later AND GPL-3.0-or-later WITH GCC-exception-3.1"
+website = "https://github.com/alire-project/GNAT-FSF-builds"
+
+auto-gpr-with = false
+
+[configuration]
+disabled = true
+
+[environment."case(os)".linux]
+PATH.prepend = "${CRATE_ROOT}/bin"
+LIBRARY_PATH.prepend = "${CRATE_ROOT}/lib64"
+LD_LIBRARY_PATH.prepend = "${CRATE_ROOT}/lib64"
+LD_RUN_PATH.prepend = "${CRATE_ROOT}/lib64"
+
+[environment."case(os)".windows."case(host-arch)".x86-64]
+PATH.prepend = "${CRATE_ROOT}/bin"
+LIBRARY_PATH.prepend = "${CRATE_ROOT}/lib"
+LD_LIBRARY_PATH.prepend = "${CRATE_ROOT}/lib"
+LD_RUN_PATH.prepend = "${CRATE_ROOT}/lib"
+
+[environment."case(os)".macos]
+PATH.prepend = "${CRATE_ROOT}/bin"
+# LIBRARY_PATH.prepend = "${CRATE_ROOT}/lib"
+LD_LIBRARY_PATH.prepend = "${CRATE_ROOT}/lib"
+LD_RUN_PATH.prepend = "${CRATE_ROOT}/lib"
+
+[origin."case(os)".linux."case(host-arch)".x86-64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-x86_64-linux-15.3.0-1.tar.gz"
+hashes = ["sha256:a6af58cbe96b8ed92b9d9929f89547c1be2ce96b86bb86422026074094429001"]
+
+[origin."case(os)".linux."case(host-arch)".aarch64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-aarch64-linux-15.3.0-1.tar.gz"
+hashes = ["sha256:322175876bf67b11d91b5cb8dea14da24b2f89f13292887222cf7f47a57f1db7"]
+
+[origin."case(os)".macos."case(host-arch)".x86-64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-x86_64-darwin-15.3.0-1.tar.gz"
+hashes = ["sha256:99f5ac7740fcc97587741d8ab17b25b3e0ce9229774e9f7788c3c1e3cedcc1b6"]
+
+[origin."case(os)".macos."case(host-arch)".aarch64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-aarch64-darwin-15.3.0-1.tar.gz"
+hashes = ["sha256:36dc731443de2b8fb00aa0a40edcb06369c6e677912ad3f045f98e1121276627"]
+
+[origin."case(os)".windows."case(host-arch)".x86-64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-x86_64-windows64-15.3.0-1.tar.gz"
+hashes = ["sha256:ebcc01066d1ebd319037bdd0f5bf6c068055b2c86f60945ed7e9c8cf96fd0dbb"]

--- a/index/gn/gnat_riscv64_elf/gnat_riscv64_elf-15.3.1.toml
+++ b/index/gn/gnat_riscv64_elf/gnat_riscv64_elf-15.3.1.toml
@@ -1,0 +1,41 @@
+name = "gnat_riscv64_elf"
+version = "15.3.1"
+provides = ["gnat=15.3.1"]
+description = "The GNAT Ada compiler - RISC-V cross-compiler"
+maintainers = ["chouteau@adacore.com", "sagaert@adacore.com"]
+maintainers-logins = ["Fabien-Chouteau", "AldanTanneo"]
+licenses = "GPL-3.0-or-later AND GPL-3.0-or-later WITH GCC-exception-3.1"
+website = "https://github.com/alire-project/GNAT-FSF-builds"
+
+auto-gpr-with = false
+
+[configuration]
+disabled = true
+
+[environment]
+PATH.prepend = "${CRATE_ROOT}/bin"
+
+[origin."case(os)".linux."case(host-arch)".x86-64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-riscv64-elf-linux64-x86_64-15.3.0-1.tar.gz"
+hashes = ["sha256:b983cb8572f10894e2d8788e56b9591d1d4586d62b558a0b7930b1416ddf2654"]
+
+[origin."case(os)".linux."case(host-arch)".aarch64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-riscv64-elf-linux64-aarch64-15.3.0-1.tar.gz"
+hashes = ["sha256:c75f92e4b76c3a8c628cc24f6e648cd203023afa25c742cd4aa09a09aa329602"]
+
+[origin."case(os)".macos."case(host-arch)".x86-64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-riscv64-elf-darwin-x86_64-15.3.0-1.tar.gz"
+hashes = ["sha256:56689e6db001d514a011164347bea9a2b0cca803e97b3babd17d3bf15ea1ad51"]
+
+[origin."case(os)".macos."case(host-arch)".aarch64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-riscv64-elf-darwin-aarch64-15.3.0-1.tar.gz"
+hashes = ["sha256:25ba2f188d2e46d30f098f9760288008596b07de6431ed54a6814db42facd416"]
+
+[origin."case(os)".windows."case(host-arch)".x86-64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-riscv64-elf-windows64-x86_64-15.3.0-1.tar.gz"
+hashes = ["sha256:b9191cacd36cbd0843846ad0548b377abb17594188997a0f3e620e449966a3b0"]

--- a/index/gn/gnat_x86_64_elf/gnat_x86_64_elf-15.3.1.toml
+++ b/index/gn/gnat_x86_64_elf/gnat_x86_64_elf-15.3.1.toml
@@ -1,0 +1,41 @@
+name = "gnat_x86_64_elf"
+version = "15.3.1"
+provides = ["gnat=15.3.1"]
+description = "The GNAT Ada compiler - x86_64 cross-compiler"
+maintainers = ["chouteau@adacore.com", "sagaert@adacore.com"]
+maintainers-logins = ["Fabien-Chouteau", "AldanTanneo"]
+licenses = "GPL-3.0-or-later AND GPL-3.0-or-later WITH GCC-exception-3.1"
+website = "https://github.com/alire-project/GNAT-FSF-builds"
+
+auto-gpr-with = false
+
+[configuration]
+disabled = true
+
+[environment]
+PATH.prepend = "${CRATE_ROOT}/bin"
+
+[origin."case(os)".linux."case(host-arch)".x86-64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-x86_64-elf-linux64-x86_64-15.3.0-1.tar.gz"
+hashes = ["sha256:3133ed74472491a5c4fee6f23251ce3e0f26c0cbb63b57da0f1917fffed1c8a9"]
+
+[origin."case(os)".linux."case(host-arch)".aarch64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-x86_64-elf-linux64-aarch64-15.3.0-1.tar.gz"
+hashes = ["sha256:eae642de45817feb2f5d325e9a6b8759090c2918e8a6732d4ec66501f6b5bcf4"]
+
+[origin."case(os)".macos."case(host-arch)".x86-64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-x86_64-elf-darwin-x86_64-15.3.0-1.tar.gz"
+hashes = ["sha256:b130a96b590f776c5de931f967dda607ef577abf8ad0b08b13e2c89375573a8f"]
+
+[origin."case(os)".macos."case(host-arch)".aarch64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-x86_64-elf-darwin-aarch64-15.3.0-1.tar.gz"
+hashes = ["sha256:07e52e6ebdaaca0093b06cb5bd9c55a24ac464001282161f3d8113f8a0dab411"]
+
+[origin."case(os)".windows."case(host-arch)".x86-64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-x86_64-elf-windows64-x86_64-15.3.0-1.tar.gz"
+hashes = ["sha256:880685c3433d4c8b8ecb0f1fa40e89f8ab2e82faa6f51b4d868fe44fc9ee48f3"]

--- a/index/gn/gnat_xtensa_esp32_elf/gnat_xtensa_esp32_elf-15.3.1.toml
+++ b/index/gn/gnat_xtensa_esp32_elf/gnat_xtensa_esp32_elf-15.3.1.toml
@@ -1,0 +1,41 @@
+name = "gnat_xtensa_esp32_elf"
+version = "15.3.1"
+provides = ["gnat=15.3.1"]
+description = "The GNAT Ada compiler - ESP32 cross-compiler"
+maintainers = ["chouteau@adacore.com", "sagaert@adacore.com"]
+maintainers-logins = ["Fabien-Chouteau", "AldanTanneo"]
+licenses = "GPL-3.0-or-later AND GPL-3.0-or-later WITH GCC-exception-3.1"
+website = "https://github.com/alire-project/GNAT-FSF-builds"
+
+auto-gpr-with = false
+
+[configuration]
+disabled = true
+
+[environment]
+PATH.prepend = "${CRATE_ROOT}/bin"
+
+[origin."case(os)".linux."case(host-arch)".x86-64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-xtensa-esp32-elf-linux64-x86_64-15.3.0-1.tar.gz"
+hashes = ["sha256:97d93af65996203ae4c55851e79817891a2ad4cbbb931d35b37b56e92b9b2972"]
+
+[origin."case(os)".linux."case(host-arch)".aarch64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-xtensa-esp32-elf-linux64-aarch64-15.3.0-1.tar.gz"
+hashes = ["sha256:aa2b4a241601434c1293304f9df2c9c13a850466eb7c730384bc03cbd402cdd3"]
+
+[origin."case(os)".macos."case(host-arch)".x86-64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-xtensa-esp32-elf-darwin-x86_64-15.3.0-1.tar.gz"
+hashes = ["sha256:46c0fb8e5e403905b1f87cd6718b697518a6166789c45ea2e73cdf9d359768ee"]
+
+[origin."case(os)".macos."case(host-arch)".aarch64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-xtensa-esp32-elf-darwin-aarch64-15.3.0-1.tar.gz"
+hashes = ["sha256:32ccddc2770a302019b91bf1a12a300060f14111bb7ba5d93da032e8ce69d22b"]
+
+[origin."case(os)".windows."case(host-arch)".x86-64]
+binary = true
+url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.3.0-1/gnat-xtensa-esp32-elf-windows64-x86_64-15.3.0-1.tar.gz"
+hashes = ["sha256:e56ee7728966d597a0416a47e3fe2ebc0be24068b7353767763c14c195db8eeb"]


### PR DESCRIPTION
This is the latest point release of GNAT FSF 15.

It includes two new cross compilers: one for aarch64-elf and another for x86_64-elf.