### PR TITLE
Add cbor_ada 0.3.0

### DIFF
--- a/index/cb/cbor_ada/cbor_ada-0.3.0.toml
+++ b/index/cb/cbor_ada/cbor_ada-0.3.0.toml
@@ -1,0 +1,30 @@
+name = "cbor_ada"
+description = "CBOR (RFC 8949) encoding/decoding library with SPARK formal verification"
+version = "0.3.0"
+
+authors = ["Baris Erdem"]
+maintainers = ["Baris Erdem <baris@erdem.dev>"]
+maintainers-logins = ["b-erdem"]
+licenses = "Apache-2.0"
+website = "https://github.com/b-erdem/cbor_ada"
+tags = ["cbor", "rfc8949", "serialization", "spark", "embedded", "iot", "verified"]
+
+long-description = """
+SPARK-proved CBOR encoder/decoder for Ada 2022. The entire library is
+formally verified at SPARK Level 2: 1082/1082 proof obligations discharged,
+0 unproved, 0 pragma Assume. Beyond absence of run-time errors, the
+encode/decode round trip is machine-proved -- Decode (Encode (x)) = x for
+every major-type head (integers, tags, array/map headers, simple values,
+booleans, null/undefined) and byte-exact float payload pass-through -- via a
+shared ghost denotation of the wire format.
+
+No heap allocation, pragma Pure, suitable for embedded and safety-critical
+systems. Full RFC 8949 well-formedness validation including shortest-form
+checking, configurable nesting depth, string length limits, and optional
+UTF-8 validation.
+"""
+
+[origin]
+commit = "b448c366117ff9f6c050b13d4fe609bb79495759"
+url = "git+https://github.com/b-erdem/cbor_ada.git"
+


### PR DESCRIPTION
New release of cbor_ada (already in the index at 0.2.0).

**Headline: the encode/decode round trip is now machine-proved.**
`Decode (Encode (x)) = x` is a SPARK theorem for every RFC 8949 major-type head (integers, tags, array/map headers, simple values, booleans, null/undefined) plus byte-exact float payload pass-through — functional correctness beyond absence of run-time errors, via a shared ghost denotation (`CBOR.Model`) the encoder and decoder are both specified against.

- Whole library: **1082/1082 VCs proved at level 2, 0 unproved, 0 `pragma Assume`** (was 517 core VCs with the round-trip lemmas open).
- No heap, `pragma Pure`, full RFC 8949 well-formedness validation. Apache-2.0.

Repo: https://github.com/b-erdem/cbor_ada (tag v0.3.0).