### PR TITLE
Add ml_kem 1.0.0

### DIFF
--- a/index/ml/ml_kem/ml_kem-1.0.0.toml
+++ b/index/ml/ml_kem/ml_kem-1.0.0.toml
@@ -1,0 +1,44 @@
+name = "ml_kem"
+description = "SPARK-proved ML-KEM (FIPS 203) lattice-based key encapsulation"
+version = "1.0.0"
+
+authors = ["Baris Erdem"]
+maintainers = ["Baris Erdem <baris@erdem.dev>"]
+maintainers-logins = ["b-erdem"]
+licenses = "GPL-3.0-only"
+website = "https://github.com/b-erdem/ml_kem_ada"
+tags = ["ml-kem", "post-quantum", "cryptography", "spark", "embedded", "security", "verified"]
+
+long-description = """
+SPARK-proved ML-KEM (Module-Lattice-Based Key-Encapsulation Mechanism)
+implementing NIST FIPS 203. Formally verified at SPARK level 2 with zero
+pragma Assume, zero unproved VCs. The 7-layer Cooley-Tukey NTT, BaseMul,
+IndCPA, and FO transform are all proved end-to-end with no escape hatches.
+
+All three FIPS 203 parameter sets -- ML-KEM-512, ML-KEM-768, ML-KEM-1024
+-- are supported and selected at build time via the `parameter_set`
+crate configuration variable; default is ML-KEM-768 (NIST Category III).
+
+Proof techniques are documented in PROOF_NOTES.md and reusable for similar
+lattice / ARX cryptography.
+
+Built on sha3_ada for SHA-3/SHAKE. No heap allocation, pragma Pure, suitable
+for embedded and safety-critical systems. Constant-time execution
+empirically verified via cachegrind (LLd byte-identical). FIPS 140-3
+validation is out of scope. See SECURITY.md for the full threat model.
+"""
+
+project-files = ["ml_kem_ada.gpr"]
+
+[configuration.variables]
+parameter_set = { type = "Enum", values = ["ML_KEM_512", "ML_KEM_768", "ML_KEM_1024"], default = "ML_KEM_768" }
+
+[[depends-on]]
+gnat = ">=14.2.1"
+sha3 = "~1.0"
+
+
+[origin]
+commit = "0b46ce23243d75f11746112c70a6d80799d85e58"
+url = "git+https://github.com/b-erdem/ml_kem_ada.git"
+


### PR DESCRIPTION
FIPS 203 ML-KEM (Kyber) in SPARK/Ada — all three parameter sets (ML-KEM-512/768/1024 via the `parameter_set` crate config).

- **Formally verified at SPARK level 2: 2204/2204 VCs proved, 0 unproved, 0 `pragma Assume`, 0 escape hatches.**
- FIPS 203 §4.2.1 serialization round-trips machine-proved: `ByteDecode_d(ByteEncode_d(x)) = x` for d = 1, 4, 10, 12.
- Empirical constant-time evidence (cachegrind LLd byte-identical).
- Depends on `sha3`. No heap, `pragma Pure`.
- Dual-licensed GPL-3.0-only / commercial.

Repo: https://github.com/b-erdem/ml_kem_ada (tag v1.0.0; crate name `ml_kem`, repo stays `ml_kem_ada`).