### PR TITLE
Add ml_dsa 1.0.0

### DIFF
--- a/index/ml/ml_dsa/ml_dsa-1.0.0.toml
+++ b/index/ml/ml_dsa/ml_dsa-1.0.0.toml
@@ -1,0 +1,46 @@
+name = "ml_dsa"
+description = "SPARK-proved ML-DSA (FIPS 204) lattice-based digital signatures"
+version = "1.0.0"
+
+authors = ["Baris Erdem"]
+maintainers = ["Baris Erdem <baris@erdem.dev>"]
+maintainers-logins = ["b-erdem"]
+licenses = "GPL-3.0-only"
+website = "https://github.com/b-erdem/ml_dsa_ada"
+tags = ["ml-dsa", "dilithium", "post-quantum", "cryptography", "spark", "embedded", "security", "verified"]
+
+long-description = """
+SPARK-proved ML-DSA (Module-Lattice-Based Digital Signature Algorithm)
+implementing NIST FIPS 204. Verifies signing and verification under
+the Module Learning With Errors (M-LWE) assumption.
+
+All three FIPS 204 parameter sets -- ML-DSA-44, ML-DSA-65, ML-DSA-87
+-- are supported and selected at build time via the `parameter_set`
+crate configuration variable; default is ML-DSA-65 (NIST Category III).
+
+The 8-layer Cooley-Tukey NTT, Montgomery reduction, Power2Round /
+Decompose / MakeHint / UseHint rounding primitives, and bounded
+rejection-sampling loops for signing are all SPARK-checked. The
+signing rejection loop is bounded (Max_Retries = 1000) for proof
+termination; rejection probability per attempt is empirically ~2-4%,
+so the bound is reached only with negligible probability.
+
+Built on sha3_ada for SHA-3/SHAKE. No heap allocation, pragma Pure,
+suitable for embedded and safety-critical systems. FIPS 140-3
+validation is out of scope.
+"""
+
+project-files = ["ml_dsa_ada.gpr"]
+
+[configuration.variables]
+parameter_set = { type = "Enum", values = ["ML_DSA_44", "ML_DSA_65", "ML_DSA_87"], default = "ML_DSA_65" }
+
+[[depends-on]]
+gnat = ">=14.2.1"
+sha3 = "~1.0"
+
+
+[origin]
+commit = "259116004ff3cff337950d5cf87e905eda3695f7"
+url = "git+https://github.com/b-erdem/ml_dsa_ada.git"
+


### PR DESCRIPTION
FIPS 204 ML-DSA (Dilithium) in SPARK/Ada — all three parameter sets (ML-DSA-44/65/87 via the `parameter_set` crate config).

- **Formally verified at SPARK level 2: 1898/1898 VCs proved, 0 unproved, 0 `pragma Assume`, 0 escape hatches.**
- Rounding identities machine-proved (Power2Round exact reconstruction; Decompose mod-q congruence).
- ACVP byte-exact tested; constant-time disassembly check in CI.
- Depends on `sha3`. No heap, `pragma Pure`.
- Dual-licensed GPL-3.0-only / commercial.

Repo: https://github.com/b-erdem/ml_dsa_ada (tag v1.0.0; crate name `ml_dsa`, repo stays `ml_dsa_ada`).