### PR TITLE
sparklib fsf library_kind hotfix

### DIFF
--- a/index/sp/sparklib/sparklib-16.1.0.toml
+++ b/index/sp/sparklib/sparklib-16.1.0.toml
@@ -32,6 +32,10 @@ SPARKLIB_INSTALLED = "False"
 type = "post-fetch"
 command = ["sed", "-i", "-e", "s/type SPARKlib_Library_Kind is (\"static\");/type SPARKlib_Library_Kind is (\"static\", \"static-pic\", \"relocatable\");/", "sparklib.gpr"]
 
+[[actions]]
+type = "post-fetch"
+command = ["sed", "-i", "-e", "s/\"-gnatygo-u\"/\"-gnatygo-ud\"/", "sparklib_common.gpr"]
+
 [[forbids]]
 gnatprove = "<16"
 

--- a/index/sp/sparklib/sparklib-16.1.0.toml
+++ b/index/sp/sparklib/sparklib-16.1.0.toml
@@ -28,6 +28,10 @@ SPARKLIB_BUILD = ["Production", "Assertions", "Debug"]
 [gpr-set-externals]
 SPARKLIB_INSTALLED = "False"
 
+[[actions]]
+type = "post-fetch"
+command = ["sed", "-i", "-e", "s/type SPARKlib_Library_Kind is (\"static\");/type SPARKlib_Library_Kind is (\"static\", \"static-pic\", \"relocatable\");/", "sparklib.gpr"]
+
 [[forbids]]
 gnatprove = "<16"
 


### PR DESCRIPTION
Patch the `SPARKlib_Library_Kind` type, that hasn't been modified to accept `relocatable` and `static-pic` libraries. See https://github.com/AdaCore/SPARKlib/issues/2.