### PR TITLE
libsdl2: use sdl2-compat for Arch (sdl2 left official repos)

### DIFF
--- a/index/li/libsdl2/libsdl2-external.toml
+++ b/index/li/libsdl2/libsdl2-external.toml
@@ -8,7 +8,7 @@ maintainers-logins = ["mosteo"]
 kind = "system"
     [external.origin.'case(distribution)']
     'debian|ubuntu' = ["libsdl2-dev"]
-    'arch' = ["sdl2"]
+    'arch' = ["sdl2-compat"]
     'centos|fedora' = ["SDL2-devel"]
     'homebrew' = ["sdl2"]
     'macports' = ["libsdl2"]


### PR DESCRIPTION
As of 2025-01, Arch removed `sdl2` from the official repositories and replaced it with `sdl2-compat` (SDL3-backed, in `extra`), which carries `provides=(sdl2)` / `conflicts=(sdl2)`; the old `sdl2` moved to the AUR.

Because alr's pacman probe matches the literal package name and does not resolve `provides`, `libsdl2` is no longer detected on current Arch even when sdl2-compat is installed. This breaks `alr build` / `alr publish` for any crate depending on libsdl2 (hit while publishing lace's `gel`), with:

    error: you cannot perform this operation unless you are root.

Switching the arch origin to `sdl2-compat` restores detection and install. Ref: https://archlinux.org/packages/extra/x86_64/sdl2-compat/