### PR TITLE
adacovex 1.0.0 (via `alr publish`)

### DIFF
--- a/index/ad/adacovex/adacovex-1.0.0.toml
+++ b/index/ad/adacovex/adacovex-1.0.0.toml
@@ -1,0 +1,35 @@
+name = "adacovex"
+description = "Ada/SPARK coverage, proof, DO-178C compliance tool"
+version = "1.0.0"
+long-description = """
+Zero-dependency Ada/SPARK CLI tool for coverage analysis, proof verification,
+test-result parsing, DO-178C DAL compliance assessment, and interactive dashboards.
+
+- Source scanning: walks .ads files, extracts subprogram declarations, docstring
+  annotations (@param, @return, @field, @formal), and HLR traceability tags
+- Proof analysis: parses GNATprove gnatprove.out summaries; assesses SPARK
+  assurance levels (Stone through Platinum)
+- Test parsing: reads markdown test results for pass/fail counts (native Ada or
+  AUnit format)
+- DAL compliance: assesses DO-178C DAL A-E criteria (HLR coverage, orphan tags,
+  test status, minimum SPARK proof level)
+- Multiple outputs: ANSI terminal report, SVG badges, Markdown reports,
+  HTML dashboard, and JSON API via built-in HTTP/1.1 server
+- Scalable: package/subprogram collections use Ada.Containers.Vectors
+  (heap-allocated, no compile-time limits)
+- No external dependencies beyond the GNAT runtime library
+- Self-assessment: 100% docstring coverage, Platinum SPARK (28/28 VCs proved),
+  DAL-C Achieved, 152/152 native tests passing
+"""
+
+authors = ["bladeacer"]
+maintainers = ["bladeacer <wg.nick.exe@gmail.com>"]
+maintainers-logins = ["bladeacer"]
+licenses = "Apache-2.0"
+website = "https://github.com/bladeacer/adacovex"
+tags = ["ada", "spark", "coverage", "do-178c", "compliance"]
+
+[origin]
+commit = "c07261bbded57e3717f5ae48a202662709d97952"
+url = "git+https://github.com/bladeacer/adacovex"
+


### PR DESCRIPTION
<img width="778" height="347" alt="image" src="https://github.com/user-attachments/assets/318e246c-9e74-4eb4-bdcf-3a80463eec26" />

Basically wanted shiny project badges generated from a CLI like in Golang/Rust. Hope this would be a useful addition for checking on code quality. Supports parsing SPARK level, unit tests, DO-178 HAL level and docstrings coverage.

Repo URL: https://github.com/bladeacer/adacovex

