### PR TITLE
adsa 1.5.0: new crate

### DIFF
--- a/index/ad/adsa/adsa-1.5.0.toml
+++ b/index/ad/adsa/adsa-1.5.0.toml
@@ -1,0 +1,41 @@
+name = "adsa"
+description = "Ada Annex E (DSA) runtime + gnatdist replacement, backed by ZeroMQ"
+version = "1.5.0"
+
+licenses = "GPL-3.0-or-later WITH GCC-exception-3.1"
+maintainers = ["Rod Kay <rodakay5@gmail.com>"]
+maintainers-logins = ["charlie5"]
+website = "https://codeberg.org/charlie5/aDSA"
+tags = ["distributed", "dsa", "annex-e", "rpc", "racw", "gnatdist", "zeromq"]
+
+long-description = """
+aDSA is a Partition Communication Subsystem (PCS) for Ada's Distributed
+Systems Annex (Annex E), replacing the discontinued PolyORB/GLADE runtime.
+`alr build` produces two ordinary tools:
+
+  * `pcs_gnatdist` -- the gnatdist replacement: builds a distributed
+    application from its `.cfg`, auto-assembling the GARLIC runtime (a
+    `--RTS` overlay of the toolchain's own runtime) on first use and
+    re-assembling it when the toolchain changes;
+  * `pcs_supervisor` -- launches and restarts a built deployment per its
+    `.manifest`.
+
+System prerequisites beyond the toolchain: libzmq >= 4.x and zlib
+(`pacman -S zeromq`, `apt install libzmq3-dev`, `pkg install libzmq4`;
+Windows setup is in the README's Platforms section).
+
+Start with docs/users-guide.md; `examples/` holds runnable demos.
+"""
+
+executables = ["pcs_gnatdist", "pcs_supervisor"]
+project-files = ["adsa.gpr"]
+
+[[depends-on]]
+gnat = ">=12"
+
+[configuration]
+disabled = true
+
+[origin]
+url = "https://codeberg.org/charlie5/aDSA/releases/download/v1.5.0/adsa-1.5.0.tar.gz"
+hashes = ["sha512:a1887ee67bffd585445aa53b8a467783ddc7ad339df13a4c44c0b47ab2499d257041f256fbc1768be67d6a4c614078052cb446437c1c5de001875f9871ce9049"]


### PR DESCRIPTION
First release of aDSA, a ZeroMQ-backed PCS for Ada’s Distributed Systems Annex (Annex E), replacing the discontinued PolyORB runtime. Home: https://codeberg.org/charlie5/aDSA