### PR TITLE
uarp_sdk 0.5.3

### DIFF
--- a/index/ua/uarp_sdk/uarp_sdk-0.5.3.toml
+++ b/index/ua/uarp_sdk/uarp_sdk-0.5.3.toml
@@ -1,0 +1,27 @@
+name = "uarp_sdk"
+description = "Ada client for the UARP (Snaga) Universal Agent Runtime Platform API"
+version = "0.5.3"
+licenses = "MIT"
+authors = ["Snaga"]
+maintainers = ["Snaga <support@snaga.ai>"]
+maintainers-logins = ["snaga-ai", "chabanov"]
+website = "https://snaga.ai"
+tags = ["api", "http", "client", "ai", "agents", "openapi"]
+
+[[depends-on]]
+gnatcoll = "^26.0.0"
+
+#  libcurl is linked through `-lcurl` (see uarp_sdk.gpr). It ships with macOS
+#  and every mainstream Linux distribution; Alire's `libcurl` external is not
+#  declared here because its detection only covers Linux package managers.
+
+[gpr-externals]
+UARP_SDK_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
+
+[origin]
+hashes = [
+"sha256:ee69bfafb06b4a2accd4523d49cc1bb6feb7154d1e80ec151a8c327311e44a00",
+"sha512:20a1f473f7ba2d8080ee152c1bdb24fd725e2f9391b308335199bea2dae6521e8fe60ca382aa470e38fb3f67a51b78400bcee1943e3ff24341ddcae37d6ab8d0",
+]
+url = "https://github.com/Snaga-AI/uarp-sdks/releases/download/v0.5.3/uarp_sdk-0.5.3.tgz"
+


### PR DESCRIPTION
Adds `uarp_sdk` 0.5.3 — an Ada client for the UARP (Snaga) Universal Agent
Runtime Platform API. This is the crate's first submission to the index.

- Source archive is attached to the upstream GitHub release:
  https://github.com/Snaga-AI/uarp-sdks/releases/tag/v0.5.3
- Manifest generated by `alr publish` (alr 2.1.1), unedited.
- Depends on `gnatcoll^26.0.0`.
- `libcurl` is linked via `-lcurl` from the project's own GPR rather than
  declared as an external, since Alire's `libcurl` detection only covers
  Linux package managers and the crate also targets macOS.

The library builds as relocatable, static or static-pic through the
`UARP_SDK_LIBRARY_TYPE` scenario variable.