### PR TITLE
adsa 1.5.2: new release

### DIFF
--- a/index/ad/adsa/adsa-1.5.2.toml
+++ b/index/ad/adsa/adsa-1.5.2.toml
@@ -1,0 +1,41 @@
+name = "adsa"
+description = "Ada Annex E (DSA) runtime + gnatdist replacement, backed by ZeroMQ"
+version = "1.5.2"
+
+licenses = "GPL-3.0-or-later WITH GCC-exception-3.1"
+maintainers = ["Rod Kay <rodakay5@gmail.com>"]
+maintainers-logins = ["charlie5"]
+website = "https://github.com/charlie5/aDSA"
+tags = ["distributed", "dsa", "annex-e", "rpc", "racw", "gnatdist", "zeromq"]
+
+long-description = """
+aDSA is a Partition Communication Subsystem (PCS) for Ada's Distributed
+Systems Annex (Annex E), replacing the discontinued PolyORB/GLADE runtime.
+`alr build` produces two ordinary tools:
+
+  * `pcs_gnatdist` -- the gnatdist replacement: builds a distributed
+    application from its `.cfg`, auto-assembling the GARLIC runtime (a
+    `--RTS` overlay of the toolchain's own runtime) on first use and
+    re-assembling it when the toolchain changes;
+  * `pcs_supervisor` -- launches and restarts a built deployment per its
+    `.manifest`.
+
+System prerequisites beyond the toolchain: libzmq >= 4.x and zlib
+(`pacman -S zeromq`, `apt install libzmq3-dev`, `pkg install libzmq4`;
+Windows setup is in the README's Platforms section).
+
+Start with docs/users-guide.md; `examples/` holds runnable demos.
+"""
+
+executables = ["pcs_gnatdist", "pcs_supervisor"]
+project-files = ["adsa.gpr"]
+
+[[depends-on]]
+gnat = ">=12"
+
+[configuration]
+disabled = true
+
+[origin]
+url = "git+https://github.com/charlie5/aDSA.git"
+commit = "54b60db61b54dd24ca67e538a3f7d2d194948715"


### PR DESCRIPTION
New release of the adsa crate (Ada Annex E / DSA runtime + gnatdist replacement, ZeroMQ-backed).

First release using a git-tag origin from the project's GitHub home (github.com/charlie5/aDSA, moved from Codeberg — hosting-move PRs #2055/#2063). The pinned commit is the v1.5.2 tag target.

Highlights: DSA_HOST=auto advertise-address detection, IPv6 support (DSA_IPV6), a name-server warning for the classic loopback-registration misconfiguration, and a reorganized examples tree.