### PR TITLE
Add libsdl3, libsdl3_ttf and libsdl3_image externals

### DIFF
--- a/index/li/libsdl3/libsdl3-external.toml
+++ b/index/li/libsdl3/libsdl3-external.toml
@@ -1,0 +1,16 @@
+description = "Simple DirectMedia Layer 3 development files"
+name = "libsdl3"
+
+maintainers = ["ovenpasta@pizzahack.eu"]
+maintainers-logins = ["ovenpasta"]
+
+[[external]]
+kind = "system"
+    [external.origin.'case(distribution)']
+    'debian|ubuntu' = ["libsdl3-dev"]
+    'arch' = ["sdl3"]
+    'fedora' = ["SDL3-devel"]
+    'homebrew' = ["sdl3"]
+    'macports' = ["SDL3"]
+    'gentoo' = ["media-libs/libsdl3"]
+    'msys2' = ["mingw-w64-x86_64-sdl3"]

--- a/index/li/libsdl3_image/libsdl3_image-external.toml
+++ b/index/li/libsdl3_image/libsdl3_image-external.toml
@@ -1,0 +1,16 @@
+description = "Simple DirectMedia Layer 3 development files - Image"
+name = "libsdl3_image"
+
+maintainers = ["ovenpasta@pizzahack.eu"]
+maintainers-logins = ["ovenpasta"]
+
+[[external]]
+kind = "system"
+    [external.origin.'case(distribution)']
+    'debian|ubuntu' = ["libsdl3-image-dev"]
+    'arch' = ["sdl3_image"]
+    'fedora' = ["SDL3_image-devel"]
+    'homebrew' = ["sdl3_image"]
+    'macports' = ["SDL3_image"]
+    'gentoo' = ["media-libs/sdl3-image"]
+    'msys2' = ["mingw-w64-x86_64-sdl3-image"]

--- a/index/li/libsdl3_ttf/libsdl3_ttf-external.toml
+++ b/index/li/libsdl3_ttf/libsdl3_ttf-external.toml
@@ -1,0 +1,16 @@
+description = "Simple DirectMedia Layer 3 development files - TTF"
+name = "libsdl3_ttf"
+
+maintainers = ["ovenpasta@pizzahack.eu"]
+maintainers-logins = ["ovenpasta"]
+
+[[external]]
+kind = "system"
+    [external.origin.'case(distribution)']
+    'debian|ubuntu' = ["libsdl3-ttf-dev"]
+    'arch' = ["sdl3_ttf"]
+    'fedora' = ["SDL3_ttf-devel"]
+    'homebrew' = ["sdl3_ttf"]
+    'macports' = ["SDL3_ttf"]
+    'gentoo' = ["media-libs/sdl3-ttf"]
+    'msys2' = ["mingw-w64-x86_64-sdl3-ttf"]


### PR DESCRIPTION
SDL3 development files, so Ada crates binding SDL3 can declare a system dependency. The index currently has libsdl2, libsdl2_ttf, libsdl2_image and libsdl2_mixer, but nothing for SDL3.

Package names were verified against each distribution's own package database rather than pattern-matched from the SDL2 entries, which would have been wrong in three places:

- MacPorts drops the prefix: the port is `SDL3`, not `libsdl3` (`libsdl3` 404s).
- MSYS2 switched to lowercase: `mingw-w64-x86_64-sdl3`, where SDL2 is `SDL2`.
- Gentoo is split: `media-libs/libsdl3` for the core, `media-libs/sdl3-ttf` and `media-libs/sdl3-image` for the satellites.

`centos` is omitted from all three: the Fedora package pages list only F43-45 and rawhide, with no EPEL branch, so an entry there would name a package that does not resolve. Adding `centos|` later is a one-word change if EPEL picks them up.

Availability, for reference: Debian trixie and Ubuntu 25.10 / 26.04 LTS carry all three; bookworm and 24.04 LTS carry none.