### PR TITLE
adsa 1.5.3

### DIFF
--- a/index/ad/adsa/adsa-1.5.3.toml
+++ b/index/ad/adsa/adsa-1.5.3.toml
@@ -1,0 +1,41 @@
+name = "adsa"
+description = "Ada Annex E (DSA) runtime + gnatdist replacement, backed by ZeroMQ"
+version = "1.5.3"
+
+licenses = "GPL-3.0-or-later WITH GCC-exception-3.1"
+maintainers = ["Rod Kay <rodakay5@gmail.com>"]
+maintainers-logins = ["charlie5"]
+website = "https://github.com/charlie5/aDSA"
+tags = ["distributed", "dsa", "annex-e", "rpc", "racw", "gnatdist", "zeromq"]
+
+long-description = """
+aDSA is a Partition Communication Subsystem (PCS) for Ada's Distributed
+Systems Annex (Annex E), replacing the discontinued PolyORB/GLADE runtime.
+`alr build` produces two ordinary tools:
+
+  * `pcs_gnatdist` -- the gnatdist replacement: builds a distributed
+    application from its `.cfg`, auto-assembling the GARLIC runtime (a
+    `--RTS` overlay of the toolchain's own runtime) on first use and
+    re-assembling it when the toolchain changes;
+  * `pcs_supervisor` -- launches and restarts a built deployment per its
+    `.manifest`.
+
+System prerequisites beyond the toolchain: libzmq >= 4.x and zlib
+(`pacman -S zeromq`, `apt install libzmq3-dev`, `pkg install libzmq4`;
+Windows setup is in the README's Platforms section).
+
+Start with docs/users-guide.md; `examples/` holds runnable demos.
+"""
+
+executables = ["pcs_gnatdist", "pcs_supervisor"]
+project-files = ["adsa.gpr"]
+
+[[depends-on]]
+gnat = ">=12"
+
+[configuration]
+disabled = true
+
+[origin]
+url = "git+https://github.com/charlie5/aDSA.git"
+commit = "4926831cd7e06fe31c1de1bca0b4edb6c052af9c"


### PR DESCRIPTION
New release of `adsa` — a Partition Communication Subsystem for Ada's Distributed Systems Annex (Annex E), replacing the discontinued PolyORB/GLADE runtime.

Diagnostics-only release: no wire, protocol or API change (1.5.2 and 1.5.3 deployments interoperate byte-identically). It removes the three ways the PCS could fail without reporting anything — a partition whose main raised an exception deadlocked on its own serve tasks with the exception never printed; an unregistered RCI unit was ten silent seconds; and leftover build artefacts could silently strip the DSA stubs from a partition. All found via a user report on a textbook example.

Release notes: https://github.com/charlie5/aDSA/releases/tag/v1.5.3

New manifest (no published manifest modified); plain git origin pinning the release tag commit `4926831`.