### PR TITLE
Add ipfs 0.1.0

### DIFF
--- a/index/ip/ipfs/ipfs-0.1.0.toml
+++ b/index/ip/ipfs/ipfs-0.1.0.toml
@@ -1,0 +1,19 @@
+name = "ipfs"
+description = "IPFS client library for Ada: CID, CAR, UnixFS, gateway client"
+version = "0.1.0"
+
+authors = ["Konstantin Khlopkov"]
+maintainers = ["Konstantin Khlopkov <konstantin.khlopkov93@gmail.com>"]
+maintainers-logins = ["kokhlo"]
+licenses = "MIT"
+
+tags = ["ipfs", "cid", "multihash", "car", "unixfs", "gateway", "distributed"]
+
+project-files = ["ipfs.gpr"]
+
+website = "https://github.com/kokhlo/ipfs"
+
+[origin]
+commit = "39b9a1bcee676de4e3c175a1140e3fe697723620"
+url = "git+https://github.com/kokhlo/ipfs.git"
+


### PR DESCRIPTION
First release of **ipfs**: a native IPFS client library for Ada — CID, multihash, multibase, CAR v1 reader, UnixFS, and a trustless HTTP gateway client. Pure Ada, no dependencies (GNAT.Sockets only).

- Source: https://github.com/kokhlo/ipfs (tag v0.1.0)
- Tests: 137 unit tests + E2E vs local kubo gateway (fetch CAR → verify every block hash)
- License: MIT