### PR TITLE
uhppoted-lib 0.3.0

### DIFF
--- a/index/uh/uhppoted_lib/uhppoted_lib-0.3.0.toml
+++ b/index/uh/uhppoted_lib/uhppoted_lib-0.3.0.toml
@@ -1,0 +1,18 @@
+name = "uhppoted_lib"
+description = "Library for the UHPPOTE access controllers"
+version = "0.3.0"
+licenses = "MIT"
+
+authors = ["uhppoted"]
+maintainers = ["uhppoted <uhppoted.development@gmail.com>"]
+maintainers-logins = ["uhppoted", "twystd"]
+website = "https://codeberg.org/uhppoted/uhppoted-lib-ada"
+tags = ["access-control", "uhppote"]
+
+[origin]
+hashes = [
+"sha256:8e1614cf57450eacdf8d7ea9d1528892c8d53c838e6ff6ab520dd6cab5e6b37f",
+"sha512:08451dd358aa3269b8985631627bfa4cf58bab56da4131d4b6ddc0b308f93125d04b91f4b3bc73507c0a616889d1e326b58542ff9ec666884bb7fef4cd8aa060",
+]
+url = "https://codeberg.org/uhppoted/uhppoted-lib-ada/releases/download/v0.3.0/uhppoted_lib-0.3.0.tgz"
+


### PR DESCRIPTION
### Release Notes

1. Migrated from _github.com/uhppoted/uhppoted-lib-ada_ to _codeberg.org/uhppoted/uhppoted-lib-ada_.
2. Added `set-firstcard` API to configure controller managed door first-card access.
3. Added _first-card privileges_ to `get-card`, `get-card-at-index` and `put-card` APIs.
